### PR TITLE
Office Module Updates

### DIFF
--- a/modules/office.py
+++ b/modules/office.py
@@ -61,6 +61,7 @@ class Office(Module):
             # Read SWF into buffer. If compressed read uncompressed size.
             swf = data[start:start+size]
             is_compressed = False
+            swf_deflate = None
             if 'CWS' in header:
                 is_compressed = True
                 # Data after header (8 bytes) until the end is compressed


### PR DESCRIPTION
There are a few changes here. 

Moved the OLE Parser to stop repeating code.

Renamed the Time to Structure which makes more sense based on what it provided.

Macro check now also looks for VBA Projects.

Added an export function.
Will export Every OLE Stream to a specified DIR.

```
shell CVE-2012-0744-fls.xls > office -e /home/thehermit/vipertest/exptest/
[*] Saved Stream to /home/thehermit/vipertest/exptest/CompObj
[*] Saved Stream to /home/thehermit/vipertest/exptest/DocumentSummaryInformation
[*] Saved Stream to /home/thehermit/vipertest/exptest/SummaryInformation
```

Will also export any Flash Objects - and if they are compressed, decompress the datastream and save that as well.

```
[*] Saving Flash Objects
 * Saved Decompressed Flash File to /home/thehermit/vipertest/exptest/Ctls-FLASH-Decompressed1
 * Saved Flash File to /home/thehermit/vipertest/exptest/Ctls-FLASH-1
[*] Saved Stream to /home/thehermit/vipertest/exptest/Ctls
[*] Saved Stream to /home/thehermit/vipertest/exptest/Workbook
```

Also exports VBA Projects and Macros

```
[!] this file is not a stream - _VBA_PROJECT_CUR
[*] Saved Stream to /home/thehermit/vipertest/exptest/_VBA_PROJECT_CUR-PROJECT
[*] Saved Stream to /home/thehermit/vipertest/exptest/_VBA_PROJECT_CUR-PROJECTwm
[!] this file is not a stream - _VBA_PROJECT_CUR-VBA
[*] Saved Stream to /home/thehermit/vipertest/exptest/_VBA_PROJECT_CUR-VBA-Sheet1
[*] Saved Stream to /home/thehermit/vipertest/exptest/_VBA_PROJECT_CUR-VBA-_VBA_PROJECT
[*] Saved Stream to /home/thehermit/vipertest/exptest/_VBA_PROJECT_CUR-VBA-dir
```
