### PR TITLE
added "file/tags/add" to api.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -125,6 +125,16 @@ def list_tags():
         results.append(row.tag)
 
     return jsonize(results)
+    
+#TODO we might want to have this function more general and combine it with the find_file() function in order to add tags to all found files
+#TODO make the function more flexible and not only for SHA256
+@route('/file/tags/add', method='POST')
+def add_tags():
+    upload = request.forms.get('sha256')
+    tags = request.forms.get('tags')
+    db.add_tags(upload, tags)
+
+    return jsonize({'message' : 'added'})
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
There is a need to work a bit on that function but I would like to start discussion about it.

I think it makes sense to have a helper function for find files and attach tag(s) to multiple files.

Later we could add tags to the following find criteria: 
for entry in ['md5', 'sha256', 'ssdeep', 'tag', 'name', 'all']:

Example:
curl -F sha256=aa620f1588d0a1f937fb593375b31a39e112bdfefc7a08faa2d4fc133f053fe2 -F tags='foo bar' -X POST 127.0.0.1:8080/file/tags/add
