### PR TITLE
Export exeption with empty session

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -855,6 +855,11 @@ class Commands(object):
                 return
             elif opt in ('-z', '--zip'):
                 arg_zip = True
+                
+        # This command requires a session to be opened.
+        if not __sessions__.is_set():
+            print_error("No session opened")
+            return
 
         # Check for valid export path.
         if len(args) ==0:


### PR DESCRIPTION
Situation no opened session:

export -z test.zip
[!] The command export raised an exception:
Traceback (most recent call last):
  File "/home/jaegeral/viper/viper/core/ui/console.py", line 195, in start
    self.cmd.commands[root]['obj'](*args)
  File "/home/jaegeral/viper/viper/core/ui/commands.py", line 878, in cmd_export
    export_zip.write(**sessions**.current.file.path, arcname=**sessions**.current.file.name)

--> check if session is opened
