### PR TITLE
Added timeout and machine options to cuckoo module

### DIFF
--- a/modules/cuckoo.py
+++ b/modules/cuckoo.py
@@ -16,7 +16,7 @@ from viper.core.session import __sessions__
 class Cuckoo(Module):
     cmd = 'cuckoo'
     description = 'Submit the file to Cuckoo Sandbox'
-    authors = ['nex']
+    authors = ['nex', 'lnmyshkin']
 
     def run(self):
         if not __sessions__.is_set():
@@ -28,7 +28,7 @@ class Cuckoo(Module):
             return
 
         def usage():
-            print("usage: cuckoo [-H=host] [-p=port]")
+            print("usage: cuckoo [-H=host] [-p=port] [-m=machine] [-t=timeout]")
 
         def help():
             usage()
@@ -37,10 +37,12 @@ class Cuckoo(Module):
             print("\t--help (-h)\tShow this help message")
             print("\t--host (-H)\tSpecify an host (default: localhost)")
             print("\t--port (-p)\tSpecify a port (default: 8090")
+            print("\t--machine (-m)\tSpecify a machine (default: unspecified)")
+            print("\t--timeout (-t)\tSpecify a timeout (default: unspecified)")
             print("")
 
         try:
-            opts, argv = getopt.getopt(self.args, 'hH:p:', ['help', 'host=', 'port='])
+            opts, argv = getopt.getopt(self.args, 'hH:p:m:t:', ['help', 'host=', 'port=', 'machine=' 'timeout='])
         except getopt.GetoptError as e:
             print(e)
             usage()
@@ -48,6 +50,8 @@ class Cuckoo(Module):
 
         host = 'localhost'
         port = 8090
+        machine = None
+	timeout = None
 
         for opt, value in opts:
             if opt in ('-h', '--help'):
@@ -59,13 +63,28 @@ class Cuckoo(Module):
             elif opt in ('-p', '--port'):
                 if value:
                     port = value
+            elif opt in ('-m', '--machine'):
+                if value:
+                    machine = value
+            elif opt in ('-t', '--timeout'):
+                if value:
+                    timeout = value
 
         url = 'http://{0}:{1}/tasks/create/file'.format(host, port)
 
         files = dict(file=open(__sessions__.current.file.path, 'rb'))
 
+        if machine or timeout:
+            data = dict()
+
+        if machine:
+            data['machine'] = machine
+
+	if timeout:
+            data['timeout'] = timeout
+
         try:
-            response = requests.post(url, files=files)
+            response = requests.post(url, files=files, data=data)
         except requests.ConnectionError:
             print_error("Unable to connect to Cuckoo API at {0}:{1}".format(host, port))
             return


### PR DESCRIPTION
Updated cuckoo module with --timeout and --machine options to allow the user to specify the timeout for the analysis process and choose which analysis vm is used.