### PR TITLE
adding email trace, spoof check, and support for rfc822 attached message...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ bottle
 pylzma
 pyelftools
 bitstring
+dnspython
 


### PR DESCRIPTION
adds:
- email trace, which shows Received: headers in the order they were added (bottom to top) - simple and full information options
- three spoof checks: matching from/sender/return-path/reply-to; from/sender MX record and first received header; and SPF checks. note that these tests don't necessarily indicate that an email was spoofed, just highlights potentially suspicious things to look into more
- support for rfc822 attachments/forwards. attachment command will list any message/rfc822 type parts as an attachment, and extract them to a temporary name rfc822msg_[filesize].eml. useful for taking a forwarded email with malware and saving it without keeping info from the person who sent it to you.

additional requirements:
- dnspython: needed for looking up domain MX records and doing reverse lookups on IPs. if not present, will trap the exception and just not run spoof check 2 which requires it.
