### PR TITLE
elf: Check if PT_INTERP entry exists

### DIFF
--- a/modules/elf.py
+++ b/modules/elf.py
@@ -104,8 +104,11 @@ class ELF(Module):
             if segment['p_type'] == 'PT_INTERP':
                 interp = segment
                 break
-        print("Program interpreter: {0}".format(interp.get_interp_name()))
-        
+        if interp:
+            print("Program interpreter: {0}".format(interp.get_interp_name()))
+        else:
+            print_error("No PT_INTERP entry found")
+
     def dynamic(self):
         if not self.__check_session():
             return


### PR DESCRIPTION
Not every ELF file has a PT_INTERP enty. This commit will catch a
potential AttributeError if no PT_INTERP entry is found.

Before this patch:

```
viper xxx > elf interp
[!] The command elf raised an exception:
Traceback (most recent call last):
  File "/home/vault/Code/viper/viper/core/ui/console.py", line 201, in start
    module.run()
  File "/home/vault/Code/viper/modules/elf.py", line 156, in run
    self.interp()
  File "/home/vault/Code/viper/modules/elf.py", line 108, in interp
    print("Program interpreter: {0}".format(interp.get_interp_name()))
AttributeError: 'NoneType' object has no attribute 'get_interp_name'
```

After:

```
viper xxx > elf interp
[!] No PT_INTERP entry found
```
