### PR TITLE
strings: Fix a bug with IP matching and make strings behave more like GNU strings

### DIFF
--- a/modules/strings.py
+++ b/modules/strings.py
@@ -74,7 +74,7 @@ class Strings(Module):
         results = []
         for entry in strings:
             to_add = False
-            if DOMAIN_REGEX.search(entry):
+            if DOMAIN_REGEX.search(entry) and not IPV4_REGEX.search(entry):
                 if entry[entry.rfind('.') + 1:].upper() in TLD:
                     to_add = True
             elif IPV4_REGEX.search(entry):


### PR DESCRIPTION
This patchset, fixes a bug where strings wouldn't match IPs correctly and makes strings behave more like GNU strings. 

The previous regular expression that was used in strings didn't match the SPACE character.

---

Example

```
vault@viper:~/Code/viper [master]$ cat /tmp/roz
This is a test
to see how the new regex will
react!
```

Old behaviour:

```
viper roz > strings -a                                                                                                                     
This
test
regex
will
react
```

New behaviour:

```
viper roz > strings -a                                                      
This is a test
to see how the new regex will
react
```
