### PR TITLE
Removing unwanted characters in outputs

### DIFF
--- a/web.py
+++ b/web.py
@@ -138,7 +138,7 @@ def parse_text(module_text):
         if 'Session opened on' in line:
             continue
         # add text the string
-        set_text += '{0}\n'.format(line)
+        set_text += '{0}'.format(line)
     return set_text
 
 def project_list():
@@ -599,7 +599,7 @@ def run_module():
     else:
         module_results = "You Didn't Enter A Command!"
     
-    return '<pre>{0}</pre>'.format(str(module_results))
+    return '<pre>{0}</pre>'.format(str(parse_text(module_results)))
     
 
 # Yara Rules


### PR DESCRIPTION
When I run Imphash from web, or other modules options like pehash, I get results like:

<code>
Imphash: [1medafdbe653f2711ef63542542d465a05[0m
PEhash: [1ma03602764efd702ed8457afa0d0f48651a2090f7[0m
</code>

So I use the unused (until now, maybe forgot,...) parse_text function to fix the output