### PR TITLE
Removing unwanted characters from outputs

### DIFF
--- a/web.py
+++ b/web.py
@@ -616,7 +616,7 @@ def run_module():
     else:
         module_results = "You Didn't Enter A Command!"
     
-    return '<pre>{0}</pre>'.format(str(module_results))
+    return '<pre>{0}</pre>'.format(str(parse_text(module_results)))
     
 
 # Yara Rules


### PR DESCRIPTION
Hi, 

The fix here is to the same from here https://github.com/viper-framework/viper/pull/305

Just to remember:

> When I run Imphash from web, or other modules options like pehash, I get results like:
>
> Imphash: �[1medafdbe653f2711ef63542542d465a05�[0m 
> PEhash: �[1ma03602764efd702ed8457afa0d0f48651a2090f7�[0m
> 
> So I use the unused (until now, maybe forgot,...) parse_text function to fix the output
