### PR TITLE
Remove unnecessary argument.

### DIFF
--- a/modules/pdns.py
+++ b/modules/pdns.py
@@ -21,7 +21,7 @@ class Pdns(Module):
         self.parser.add_argument("--url", help='URL of the Passive DNS server')
         self.parser.add_argument("-u", "--user", help='Username on the PDNS instance')
         self.parser.add_argument("-p", "--password", help='Password on the PDNS instance')
-        self.parser.add_argument("-q", "--query", required=True, help='Domain or IP address to query')
+        self.parser.add_argument("query", help='Domain or IP address to query')
 
     def run(self):
         super(Pdns, self).run()


### PR DESCRIPTION
There is only one kind of query type in this module. We can simply use a positional argument.