### PR TITLE
Initial removal of M2Crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ bitstring
 dnspython
 git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool
 pyasn1
-M2Crypto
 pymisp
 django
 pypssl
@@ -24,3 +23,5 @@ scandir
 pbkdf2
 r2pipe
 git+https://github.com/crackinglandia/pype32.git#egg=pype32
+cffi
+git+https://github.com/pyca/cryptography.git


### PR DESCRIPTION
Related #362 

The counterSignature check seems to always fail but the rest is working. Uses the git version of cryptography because it has parameters such as `signature` and `tbs_certificate_bytes`