### PR TITLE
Ouptut logging

### DIFF
--- a/viper/common/abstracts.py
+++ b/viper/common/abstracts.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import argparse
+import viper.common.out as out
 
 
 class ArgumentErrorCallback(Exception):
@@ -52,6 +53,10 @@ class Module(object):
             type=event_type,
             data=event_data
         ))
+        if event_type == 'table':
+            print out.table(event_data['header'], event_data['rows'])
+        else:
+            getattr(out, 'print_{0}'.format(event_type))(event_data)
 
     def usage(self):
         self.log('', self.parser.format_usage())

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     from os import walk
 
+import viper.common.out as out
 from viper.common.out import *
 from viper.common.utils import convert_size
 from viper.common.objects import File
@@ -72,6 +73,10 @@ class Commands(object):
             type=event_type,
             data=event_data
         ))
+        if event_type == 'table':
+            print table(event_data['header'], event_data['rows'])
+        else:
+            getattr(out, 'print_{0}'.format(event_type))(event_data)
 
     ##
     # CLEAR

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -225,7 +225,6 @@ class Console(object):
                         # execute it.
                         if root in self.cmd.commands:
                             self.cmd.commands[root]['obj'](*args)
-                            # print_output(self.cmd.output, filename)
                             del(self.cmd.output[:])
                         # If the root command is part of loaded modules, we initialize
                         # the module and execute it.
@@ -234,7 +233,6 @@ class Console(object):
                             module.set_commandline(args)
                             module.run()
 
-                            # print_output(module.output, filename)
                             if cfg.modules.store_output and __sessions__.is_set():
                                 try:
                                     Database().add_analysis(__sessions__.current.file.sha256, split_command, module.output)

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -225,7 +225,7 @@ class Console(object):
                         # execute it.
                         if root in self.cmd.commands:
                             self.cmd.commands[root]['obj'](*args)
-                            print_output(self.cmd.output, filename)
+                            # print_output(self.cmd.output, filename)
                             del(self.cmd.output[:])
                         # If the root command is part of loaded modules, we initialize
                         # the module and execute it.
@@ -234,7 +234,7 @@ class Console(object):
                             module.set_commandline(args)
                             module.run()
 
-                            print_output(module.output, filename)
+                            # print_output(module.output, filename)
                             if cfg.modules.store_output and __sessions__.is_set():
                                 try:
                                     Database().add_analysis(__sessions__.current.file.sha256, split_command, module.output)


### PR DESCRIPTION
Keeps the logging in the same format, so we dont need to change all the modules etc. 
The output is still available as a single dict for use in other apps like web / api.
But now prints live to the screen when running in console.