### PR TITLE
[OUT] Fix help display for modules.

### DIFF
--- a/viper/common/abstracts.py
+++ b/viper/common/abstracts.py
@@ -54,9 +54,11 @@ class Module(object):
             data=event_data
         ))
         if event_type == 'table':
-            print out.table(event_data['header'], event_data['rows'])
-        else:
+            print(out.table(event_data['header'], event_data['rows']))
+        elif event_type:
             getattr(out, 'print_{0}'.format(event_type))(event_data)
+        else:
+            print(event_data)
 
     def usage(self):
         self.log('', self.parser.format_usage())


### PR DESCRIPTION
`event_type` is an empty string if you do `<module> -h` so it was crashing:
```
viper  [MISP 2686] > pssl -h                                          
[!] The command pssl raised an exception:                                     
Traceback (most recent call last):                                            
  File "/home/raphael/gits/viper/viper/core/ui/console.py", line 234, in start
    module.run()                                                              
  File "/home/raphael/gits/viper/modules/pssl.py", line 102, in run           
    super(Pssl, self).run()                                                   
  File "/home/raphael/gits/viper/viper/common/abstracts.py", line 71, in run  
    self.log(*e.get())                                                        
  File "/home/raphael/gits/viper/viper/common/abstracts.py", line 59, in log  
    getattr(out, 'print_{0}'.format(event_type))(event_data)                  
AttributeError: 'module' object has no attribute 'print_'                     
```