### PR TITLE
fixing ascii encoding error

### DIFF
--- a/modules/elf.py
+++ b/modules/elf.py
@@ -40,8 +40,8 @@ class ELF(Module):
             try:
                 fd = open(__sessions__.current.file.path, 'rb')
                 self.elf = ELFFile(fd)
-            except:
-                self.log('error', "Unable to parse ELF file")
+            except Exception as e:
+                self.log('error', "Unable to parse ELF file: {0}".format(e))
                 return False
 
         return True

--- a/web.py
+++ b/web.py
@@ -136,7 +136,7 @@ def print_output(output):
             for row in entry['data']['rows']:
                 return_html += '<tr>'
                 for cell in row:
-                    return_html += '<td>{0}</td>'.format(cell)
+                    return_html += u'<td>{0}</td>'.format(cell)
                 return_html += '</tr>'
             # Close table
             return_html += '</table>'
@@ -155,7 +155,7 @@ def parse_text(module_text):
         if 'Session opened on' in line:
             continue
         # add text the string
-        set_text += '{0}\n'.format(line)
+        set_text += u'{0}\n'.format(line)
     return set_text
 
 def project_list():
@@ -617,7 +617,7 @@ def run_module():
     else:
         module_results = "You Didn't Enter A Command!"
 
-    return '<pre>{0}</pre>'.format(str(parse_text(module_results)))
+    return '<pre>{0}</pre>'.format(str(parse_text(module_results).encode('utf8')))
 
 
 # Yara Rules


### PR DESCRIPTION
When using web.py I regularly get unicode errors when running some modules. 
An example of an error is:
```
The Command 'exif ' generated an error. 
'ascii' codec can't encode character u'\xae' in position 0: ordinal not in range(128)
```
This is because the module outputed a character in unicode that was not convertible into ascii. Line 620 forces the data to be ascii, but also python weirdness results in some ascii strings underway causing issues.

This pull requests resolves the encoding issues.