### PR TITLE
Per-user configuration + some cleanup to project/repository management

### DIFF
--- a/viper.conf.sample
+++ b/viper.conf.sample
@@ -9,9 +9,8 @@
 store_output = True
 
 [paths]
-# root path for project storage
-# If blank default is vipers cwd
-store_path =
+# default repository root
+store_path = /path/to/default/repository/root
 
 [database]
 # Configure the database connection type example shown below

--- a/viper.py
+++ b/viper.py
@@ -15,12 +15,5 @@ args = parser.parse_args()
 if args.project:
     __project__.open(args.project)
 
-config_file = 'viper.conf'
-if not os.path.exists(config_file):
-    print ""
-    print "[!] Unable to find config file at {0}".format(config_file)
-    print ""
-else:
-    c = console.Console()
-    c.start()
-
+c = console.Console()
+c.start()

--- a/viper.py
+++ b/viper.py
@@ -9,11 +9,17 @@ from viper.core.ui import console
 from viper.core.project import __project__
 
 parser = argparse.ArgumentParser()
+parser.add_argument('-r', '--repository', help='Specify a new or existing repository', action='store', required=False)
 parser.add_argument('-p', '--project', help='Specify a new or existing project name', action='store', required=False)
 args = parser.parse_args()
 
-if args.project:
-    __project__.open(args.project)
+repository_root = None
+if args.repository:
+	repository_root = args.repository
 
-c = console.Console()
-c.start()
+project_name = None
+if args.project:
+	project_name = args.project
+
+c = console.Console(repository_root)
+c.start(project_name)

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -12,11 +12,12 @@ from viper.common.objects import Dictionary
 class Config:
     
     def __init__(self, file_name="viper", cfg=None):
-    
+        default_configuration_path = os.path.expanduser('~/.viper.conf')
+
         config = ConfigParser.ConfigParser()
-        
+
         if cfg == None:
-            cfg = os.path.expanduser('~/.viper.conf')
+            cfg = default_configuration_path
 
         test = config.read(cfg)
 
@@ -25,8 +26,18 @@ class Config:
             print_error("Could not find a valid configuration file. Did you copy viper.conf.sample to ~/.viper.conf?")
             print_info("Trying to create config for you")
             try:
-                shutil.copy('viper.conf.sample', 'viper.conf')
-                config.read('viper.conf')
+                viper_installation_directory = os.path.dirname(os.path.realpath(__file__))
+                sample_configuration_path = os.path.join(viper_installation_directory, '../../viper.conf.sample')
+
+                shutil.copy(sample_configuration_path, default_configuration_path)
+
+                config.read(default_configuration_path)
+                default_repository_path = os.path.expanduser('~/Viper')
+
+                print_info("Setting \"" + default_repository_path + "\" as your default repository...")
+                config.set('paths', 'store_path', default_repository_path)
+                config.write(open(default_configuration_path, "w"))
+
                 print_info("Starting Viper")
             except:
                 print_error("Failed to Create config file, Exiting")

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -15,14 +15,14 @@ class Config:
     
         config = ConfigParser.ConfigParser()
         
-        if cfg:
-            test = config.read(cfg)
-        else:
-            test = config.read('viper.conf')
-            
+        if cfg == None:
+            cfg = os.path.expanduser('~/.viper.conf')
+
+        test = config.read(cfg)
+
         # Check for empty config
         if len(test) == 0:
-            print_error("Could not find a valid configuration file. Did you rename viper.conf.sample to viper.conf")
+            print_error("Could not find a valid configuration file. Did you copy viper.conf.sample to ~/.viper.conf?")
             print_info("Trying to create config for you")
             try:
                 shutil.copy('viper.conf.sample', 'viper.conf')

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -178,8 +178,10 @@ class Analysis(Base):
 class Database:
     #__metaclass__ = Singleton
 
-    def __init__(self):
-        db_path = os.path.join(__project__.get_path(), 'viper.db')
+    def __init__(self, repository_root):
+        self._repository_root = repository_root
+
+        db_path = os.path.join(self._repository_root, 'viper.db')
 
         self.engine = create_engine('sqlite:///{0}'.format(db_path), poolclass=NullPool)
         self.engine.echo = False

--- a/viper/core/project.py
+++ b/viper/core/project.py
@@ -12,33 +12,24 @@ class Project(object):
     def __init__(self):
         self.name = None
         self.path = None
-        if cfg.paths.store_path:
-            self.path = cfg.paths.store_path
-        else:
-            self.path = VIPER_ROOT
+
+    def is_open(self):
+        if self.path == None:
+            return False
+
+        return True
+        
+    def open(self, absolute_project_path):
+        self.path = absolute_project_path
+        self.name = os.path.basename(absolute_project_path).replace(" ", "_")
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)
-        
-    def open(self, name):
-        if cfg.paths.store_path:
-            base_path = cfg.paths.store_path
-        else:
-            base_path = VIPER_ROOT
 
-        if name == 'default':
-            path = base_path
-        else:
-            path = os.path.join(base_path, 'projects', name)
-            if not os.path.exists(path):
-                os.makedirs(path)
-        self.name = name
-        self.path = path
+    def get_absolute_path(self):
+        return self.path
 
-    def get_path(self):
-        if self.path and os.path.exists(self.path):
-            return self.path
-        else:
-            return self.path
+    def get_name(self):
+        return self.name
 
 __project__ = Project()

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -41,9 +41,12 @@ except NameError:
 class Commands(object):
     output = []
 
-    def __init__(self):
+    def __init__(self, repository_root, database):
+        # save the repository root
+        self._repository_root = repository_root
+
         # Open connection to the database.
-        self.db = Database()
+        self.db = database
 
         # Map commands to their related functions.
         self.commands = dict(
@@ -766,11 +769,7 @@ class Commands(object):
         except:
             return
 
-        if cfg.paths.store_path != None:
-            projects_path = os.path.join(cfg.paths.store_path, 'projects')
-        else:
-            projects_path = os.path.join(os.getcwd(), 'projects')
-
+        projects_path = os.path.join(self._repository_root, 'projects')
         if not os.path.exists(projects_path):
             self.log('info', "The projects directory does not exist yet")
             return
@@ -793,11 +792,12 @@ class Commands(object):
                 __sessions__.close()
                 self.log('info', "Closed opened session")
 
-            __project__.open(args.switch)
+            project_absolute_path = os.path.join(self._repository_root, 'projects')
+            project_absolute_path = os.path.join(project_absolute_path, args.switch)
+            __project__.open(project_absolute_path)
+
             self.log('info', "Switched to project {0}".format(bold(args.switch)))
 
-            # Need to re-initialize the Database to open the new SQLite file.
-            self.db = Database()
         else:
             self.log('info', parser.print_usage())
 

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -766,7 +766,10 @@ class Commands(object):
         except:
             return
 
-        projects_path = os.path.join(os.getcwd(), 'projects')
+        if cfg.paths.store_path != None:
+            projects_path = os.path.join(cfg.paths.store_path, 'projects')
+        else:
+            projects_path = os.path.join(os.getcwd(), 'projects')
 
         if not os.path.exists(projects_path):
             self.log('info', "The projects directory does not exist yet")


### PR DESCRIPTION
Small adjustments to the configuration class in order to run Viper from a read-only folder. The viper.conf file is now read from ~/.viper.conf. 

The viper.conf.sample is now copied from the installation folder and automatically edited to set a default 'store_path' (currently using ~/Viper).

Made a more clear distinction between projects and repositories.