### PR TITLE
oletools and olefile are needed to run office

### DIFF
--- a/modules/office.py
+++ b/modules/office.py
@@ -410,7 +410,7 @@ class Office(Module):
             return
 
         if not HAVE_OLE:
-            self.log('error', "Missing dependency, install OleFileIO (`pip install olefile`)")
+            self.log('error', "Missing dependency, install OleFileIO (`pip install olefile oletools`)")
             return
 
         file_data = __sessions__.current.file.data


### PR DESCRIPTION
Changed the exit message to include both libraries. Both are needed for the office module to run.