### PR TITLE
Added 'ls' command that list all the sample. Slightly faster than 'find all'

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -495,3 +495,10 @@ class Database:
         session = self.Session()
         analysis = session.query(Analysis).get(analysis_id)
         return analysis
+
+
+
+    def get_all_malware(self):
+        session = self.Session()
+        return session.query(Malware.name, Malware.mime, Malware.md5).all()
+

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -65,6 +65,7 @@ class Commands(object):
             export=dict(obj=self.cmd_export, description="Export the current session to file or zip"),
             analysis=dict(obj=self.cmd_analysis, description="View the stored analysis"),
             rename=dict(obj=self.cmd_rename, description="Rename the file in the database"),
+            ls=dict(obj=self.cmd_ls, description="List all samples"),
         )
 
     # Output Logging
@@ -1007,3 +1008,23 @@ class Commands(object):
             else:
                 self.log('info', "No parent set for this sample")
 
+
+    ##
+    # LS
+    #
+    # This command shows all the files stored in
+    # the current project.
+
+    def cmd_ls(self):
+        # Search all the files matching the given parameters.
+        items = self.db.get_all_malware()
+        if not items:
+            return
+
+        # Populate the list of search results.
+        
+        # Generate a table with the results.
+        header = ['Name', 'Mime', 'MD5']
+        self.log("table", dict(header=header, rows=items))
+
+    


### PR DESCRIPTION
I in fact discovered 'find all' after implementing this, but it might be handy anyway. It doesn't loop through the rows, but just selects the necessary columns and renders the table. Not sure if there is a need for 'ls', but since it's already done I submit this request. 