### PR TITLE
Added 'ls' command and opening files by id

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -431,6 +431,8 @@ class Database:
             rows = session.query(Malware).filter(Malware.type.like('%{0}%'.format(value))).all()
         elif key == 'mime':
             rows = session.query(Malware).filter(Malware.mime.like('%{0}%'.format(value))).all()
+        elif key == 'id':
+            rows = session.query(Malware).filter(Malware.id == value).first()
         else:
             print_error("No valid term specified")
 
@@ -500,5 +502,5 @@ class Database:
 
     def get_all_malware(self):
         session = self.Session()
-        return session.query(Malware.name, Malware.mime, Malware.md5).all()
+        return session.query(Malware.id, Malware.name, Malware.size, Malware.mime, Malware.md5).all()
 

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -495,3 +495,10 @@ class Database:
         session = self.Session()
         analysis = session.query(Analysis).get(analysis_id)
         return analysis
+
+
+
+    def get_all_malware(self):
+        session = self.Session()
+        return session.query(Malware.name, Malware.mime, Malware.md5).all()
+

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -142,6 +142,7 @@ class Commands(object):
         group.add_argument('-f', '--file', action='store_true', help="Target is a file")
         group.add_argument('-u', '--url', action='store_true', help="Target is a URL")
         group.add_argument('-l', '--last', action='store_true', help="Target is the entry number from the last find command's results")
+        group.add_argument('-i', '--id', action='store_true', help="Target is a sample ID")
         parser.add_argument('-t', '--tor', action='store_true', help="Download the file through Tor")
         parser.add_argument("value", metavar='PATH, URL, HASH or ID', nargs='*', help="Target to open. Hash can be md5 or sha256. ID has to be from the last search.")
 
@@ -188,6 +189,20 @@ class Commands(object):
                     count += 1
             else:
                 self.log('warning', "You haven't performed a find yet")
+        elif args.id:
+            try:
+                id_ = int(target)
+            except ValueError as error:
+                self.log('error', "Wrong id format: '{0}'. Must be integer".format(target))
+                return
+                
+            row = self.db.find(key='id', value=id_)
+            if row:
+                __sessions__.new(get_sample_path(row.sha256))
+            else:
+                self.log('error', "id {0} not found".format(target))
+                
+        
         # Otherwise we assume it's an hash of an previously stored sample.
         else:
             target = target.strip().lower()
@@ -1024,7 +1039,7 @@ class Commands(object):
         # Populate the list of search results.
         
         # Generate a table with the results.
-        header = ['Name', 'Mime', 'MD5']
+        header = ['Id', 'Name', 'Size', 'Mime', 'MD5']
         self.log("table", dict(header=header, rows=items))
 
     

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -65,6 +65,7 @@ class Commands(object):
             export=dict(obj=self.cmd_export, description="Export the current session to file or zip"),
             analysis=dict(obj=self.cmd_analysis, description="View the stored analysis"),
             rename=dict(obj=self.cmd_rename, description="Rename the file in the database"),
+            ls=dict(obj=self.cmd_ls, description="List all samples"),
         )
 
     # Output Logging
@@ -1007,3 +1008,23 @@ class Commands(object):
             else:
                 self.log('info', "No parent set for this sample")
 
+
+    ##
+    # LS
+    #
+    # This command shows all the files stored in
+    # the current project.
+
+    def cmd_ls(self):
+        # Search all the files matching the given parameters.
+        items = self.db.get_all_malware()
+        if not items:
+            return
+
+        # Populate the list of search results.
+        
+        # Generate a table with the results.
+        header = ['Name', 'Mime', 'MD5']
+        self.log("table", dict(header=header, rows=items))
+
+    


### PR DESCRIPTION
ls - allows you to list all the samples, it should be faster than 'find all' as it doesn't loop through the rows, but renders the table directly from the SQL rows.The point of this command is to view all the files stored including the file id. As a result I had  to also implement opening files by id. For people mostly working in console it should be  easier than copy-pasting hashes. 
If needed I can re-do this pull and split it into several simpler requests as I know many people hate several features in one request.