### PR TITLE
YARA rule location fix

### DIFF
--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -39,7 +39,7 @@ class YaraScan(Module):
         parser_rules = subparsers.add_parser('rules', help='Operate on Yara rules')
         parser_rules.add_argument('-e', '--edit', help='Open an editor to edit the specified rule')
 
-        for folder in ['/usr/share/viper/yara', os.path.join(VIPER_ROOT, 'yara')]:
+        for folder in ['/usr/share/viper/yara', os.path.join(VIPER_ROOT, 'data/yara')]:
             if os.path.exists(folder):
                 self.rule_path = folder
                 break


### PR DESCRIPTION
The viper yara module generated an error because the path the code pointed to was "viper/yara" instead of "viper/data/yara". By adding the "data/" part the module is able to find the rules again. 