### PR TITLE
use hexdump -C instead of hd

### DIFF
--- a/viper-web
+++ b/viper-web
@@ -730,7 +730,7 @@ def hex_viewer():
     hex_path = get_sample_path(file_hash)
     
     # create the command string
-    hex_cmd = 'hd -s {0} -n {1} {2}'.format(hex_offset, hex_length, hex_path)
+    hex_cmd = 'hexdump -C -s {0} -n {1} {2}'.format(hex_offset, hex_length, hex_path)
     
     # get the output
     hex_string = getoutput(hex_cmd)


### PR DESCRIPTION
hd is not a command in Scientific Linux 6. The 'hexdump -C' command generates the same output and is compatible with SL6. I also tested in Ubuntu and received the same results.