### PR TITLE
Bump to bitstring 3.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.9.2
 SQLAlchemy==1.0.11
 beautifulsoup4==4.4.1
-bitstring==3.1.3
+bitstring==3.1.4
 bottle==0.12.9
 cffi==1.5.0
 dnspython==1.12.0


### PR DESCRIPTION
bitstring 3.1.3 is no longer available. See https://pypi.python.org/simple/bitstring/