### PR TITLE
Bump PyMISP, fix link to pefile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pycrypto==2.6.1
 pydeep==0.2
 pyelftools==0.23
 pylzma==0.4.8
-pymisp==2.4.49
+pymisp==2.4.51.1
 pypdns==1.3
 pypssl==2.1
 python-dateutil==2.4.2
@@ -29,7 +29,7 @@ scandir==1.2
 six==1.10.0
 terminaltables==2.1.0
 virustotal-api==1.0.9
-http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile
+https://github.com/erocarrera/pefile/files/192316/pefile-2016.3.28.tar.gz#egg=pefile
 git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool
 git+https://github.com/crackinglandia/pype32.git#egg=pype32
 git+https://github.com/pyca/cryptography.git#egg=cryptography


### PR DESCRIPTION
pefile is a quite important change: the link currently used is dead.