### PR TITLE
fixes issues when HOME is not set

### DIFF
--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+from os.path import expanduser
 import shutil
 import ConfigParser
 
@@ -15,7 +16,7 @@ class Config:
         # This should go in order from local to global.
         config_paths = [
             os.path.join(os.getcwd(), 'viper.conf'),
-            os.path.join(os.getenv('HOME'), '.viper', 'viper.conf'),
+            os.path.join(expanduser("~"), '.viper', 'viper.conf'),
             '/etc/viper/viper.conf'
         ]
 

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -34,7 +34,7 @@ class Config:
             cwd_viper = os.path.join(VIPER_ROOT, 'viper.conf.sample')
 
             # If the local storage folder doesn't exist, we create it.
-            local_storage = os.path.join(os.getenv('HOME'), '.viper')
+            local_storage = os.path.join(expanduser("~"), '.viper')
             if not os.path.exists(local_storage):
                 os.makedirs(local_storage)
 

--- a/viper/core/project.py
+++ b/viper/core/project.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+from os.path import expanduser
 
 from viper.core.config import Config
 
@@ -16,8 +17,8 @@ class Project(object):
             self.path = cfg.paths.storage_path
             self.base_path = cfg.paths.storage_path
         else:
-            self.path = os.path.join(os.getenv('HOME'), '.viper')
-            self.base_path = os.path.join(os.getenv('HOME'), '.viper')
+            self.path = os.path.join(expanduser("~"), '.viper')
+            self.base_path = os.path.join(expanduser("~"), '.viper')
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+from os.path import expanduser
 import time
 import json
 import shutil
@@ -802,7 +803,7 @@ class Commands(object):
         except:
             return
 
-        projects_path = os.path.join(os.getenv('HOME'), '.viper', 'projects')
+        projects_path = os.path.join(expanduser("~"), '.viper', 'projects')
 
         if not os.path.exists(projects_path):
             self.log('info', "The projects directory does not exist yet")

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+from os.path import expanduser
 import sys
 import glob
 import atexit
@@ -111,7 +112,7 @@ class Console(object):
 
             # Then autocomplete paths.
             if text.startswith("~"):
-                text = "{0}{1}".format(os.getenv("HOME"), text[1:])
+                text = "{0}{1}".format(expanduser("~"), text[1:])
             return (glob.glob(text+'*')+[None])[state]
 
         # Auto-complete on tabs.


### PR DESCRIPTION
Viper dies when the HOME variable is not set. This is the case when viper-web is started from systemd.
This patch makes takes the home folder in a more universal way. The result is the same = the home folder is returned.