### PR TITLE
allow unicode filenames fixes #106

### DIFF
--- a/viper/common/objects.py
+++ b/viper/common/objects.py
@@ -80,7 +80,7 @@ class File(object):
         self.children = ''
 
         if self.is_valid():
-            self.name = os.path.basename(self.path).encode('utf-8')
+            self.name = os.path.basename(self.path)
             self.size = os.path.getsize(self.path)
             self.type = self.get_type()
             self.mime = self.get_mime()

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -328,6 +328,10 @@ class Database:
 
         if isinstance(obj, File):
             try:
+                if isinstance(name, str):
+                    name_unicode = name.decode('utf-8')
+                else:
+                    name_unicode = name
                 malware_entry = Malware(md5=obj.md5,
                                         crc32=obj.crc32,
                                         sha1=obj.sha1,
@@ -337,7 +341,7 @@ class Database:
                                         type=obj.type,
                                         mime=obj.mime,
                                         ssdeep=obj.ssdeep,
-                                        name=name,
+                                        name=name_unicode,
                                         parent=parent_sha)
                 session.add(malware_entry)
                 session.commit()

--- a/viper/core/session.py
+++ b/viper/core/session.py
@@ -73,6 +73,9 @@ class Sessions(object):
         session.id = total + 1
 
         if path:
+            if isinstance(path, str):
+                path = path.decode('utf-8')
+
             if self.is_set() and misp_event is None and self.current.misp_event:
                 session.misp_event = self.current.misp_event
 
@@ -90,7 +93,7 @@ class Sessions(object):
                     session.file.parent = '{0} - {1}'.format(row[0].parent.name, row[0].parent.sha256)
                 session.file.children = Database().get_children(row[0].id)
 
-            print_info("Session opened on {0}".format(path))
+            print_info("Session opened on {0}".format(path.encode('utf-8')))
 
         if misp_event:
             if self.is_set() and path is None and self.current.file:

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -422,7 +422,7 @@ class Commands(object):
 
         def add_file(obj, tags=None):
             if get_sample_path(obj.sha256):
-                self.log('warning', "Skip, file \"{0}\" appears to be already stored".format(obj.name))
+                self.log('warning', "Skip, file \"{0}\" appears to be already stored".format(obj.name.encode('utf-8')))
                 return False
 
             if __sessions__.is_attached_misp(quiet=True):
@@ -439,7 +439,7 @@ class Commands(object):
                 # we don't want to have the binary lying in the repository with no
                 # associated database record.
                 new_path = store_sample(obj)
-                self.log("success", "Stored file \"{0}\" to {1}".format(obj.name, new_path))
+                self.log("success", "Stored file \"{0}\" to {1}".format(obj.name.encode('utf-8'), new_path))
 
             else:
                 return False

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -165,7 +165,11 @@ class Console(object):
 
             # Wait for input from the user.
             try:
-                data = input(prompt).strip()
+                if isinstance(prompt, unicode):
+                    prompt_input = prompt.encode('utf-8')
+                else:
+                    prompt_input = prompt
+                data = input(prompt_input).strip()
             except KeyboardInterrupt:
                 print("")
             # Terminate on EOF.


### PR DESCRIPTION
I had a look at this as this is affecting me too. 
The main issue is that the `__sessions__.current.file.name` is used in different ways around in the code. (str, unicode). I would use unicode everywhere and only convert when legacy functions (like raw_imput) can't handle it. Unfortunately it is a massive and unrealistic job to fix this everywhere. 

To resolve this I have added the verification and conversion steps in the most efficient locations.
Going from std_in, the storing of files and the database function.

I have tested opening files (with and without special chars), storing them, loading them from the db, and it seems to work. As a test I have also ran multiple modules with no issue.

I expect some issues to occur here and there, but only with files containing special chars. So this patch should not break existing functionality, but instead extend it.
Mostly solution for the encountered issues will be to encode the unicode variable as can be seen below.
```python
__sessions__.current.file.name.encode('utf-8')
```