### PR TITLE
Fix crash on strings -h

### DIFF
--- a/viper/modules/strings.py
+++ b/viper/modules/strings.py
@@ -236,6 +236,9 @@ class Strings(Module):
 
     def run(self):
         super(Strings, self).run()
+        
+        if self.args is None:
+            return
 
         if not (self.args.all or self.args.files or self.args.hosts or self.args.network or self.args.interesting):
             self.log('error', 'At least one of the parameters is required')


### PR DESCRIPTION
```
viper > strings -h                                                                                             
usage: strings [-h] [-a] [-F] [-H] [-N] [-I] [-s]                                                              
                                                                                                               
Extract strings from file                                                                                      
                                                                                                               
optional arguments:                                                                                            
  -h, --help         show this help message and exit                                                           
  -a, --all          Print all strings                                                                         
  -F, --files        Extract filenames from strings                                                            
  -H, --hosts        Extract IP addresses and domains from strings                                             
  -N, --network      Extract various network related strings                                                   
  -I, --interesting  Extract various interesting strings                                                       
  -s, --scan         Scan all files in the project with all the scanners                                       
                                                                                                               
[!] The command strings raised an exception:                                                                   
Traceback (most recent call last):                                                                             
  File "/home/raphael/gits/viper/viper/core/ui/console.py", line 233, in start                                 
    module.run()                                                                                               
  File "/home/raphael/gits/viper/viper/modules/strings.py", line 240, in run                                   
    if not (self.args.all or self.args.files or self.args.hosts or self.args.network or self.args.interesting):
AttributeError: 'NoneType' object has no attribute 'all'                                                       
```