### PR TITLE
Yara - bugfix in representation

### DIFF
--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -144,7 +144,7 @@ class YaraScan(Module):
                     for string in match.strings:
                         rows.append([match.rule, string_printable(string[1]), string_printable(string[0]), string_printable(string[2])])
                 else:
-                    self.log('item', match.__str__())
+                    self.log('item', match.rule)
                 # Add matching rules to our list of tags.
                 # First it checks if there are tags specified in the metadata
                 # of the Yara rule.

--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -144,7 +144,7 @@ class YaraScan(Module):
                     for string in match.strings:
                         rows.append([match.rule, string_printable(string[1]), string_printable(string[0]), string_printable(string[2])])
                 else:
-                    self.log('item', match)
+                    self.log('item', match.__str__())
                 # Add matching rules to our list of tags.
                 # First it checks if there are tags specified in the metadata
                 # of the Yara rule.


### PR DESCRIPTION
Sorry, this is a minor bugfix causing issues with the webinterface introduced with the previous pull request.

The result I used was a yara.Match object (match), while it should have been a string representation. (match.rule).
This didn't cause issues in viper-cli, however it did cause issues in viper-web.