### PR TITLE
Output redirection to file fixes #492 #183

### DIFF
--- a/viper/common/abstracts.py
+++ b/viper/common/abstracts.py
@@ -3,6 +3,8 @@
 
 import argparse
 import viper.common.out as out
+from viper.core.config import console_output
+
 
 class ArgumentErrorCallback(Exception):
     def __init__(self, message, level=''):
@@ -48,14 +50,7 @@ class Module(object):
             type=event_type,
             data=event_data
         ))
-
-        if event_type:
-            if event_type == 'table':
-                print(out.table(event_data['header'], event_data['rows']))
-            else:
-                getattr(out, 'print_{0}'.format(event_type))(event_data)
-        else:
-            print(event_data)
+        out.print_output([{'type': event_type, 'data': event_data}], console_output['filename'])
 
     def usage(self):
         self.log('', self.parser.format_usage())

--- a/viper/common/out.py
+++ b/viper/common/out.py
@@ -84,7 +84,6 @@ def print_output(output, filename=None):
                     out.write('\n')
                 else:
                     out.write('{0}\n'.format(entry['data']))
-        print_success("Output written to {0}".format(filename))
     else:
         for entry in output:
             if entry['type'] == 'info':

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -75,3 +75,7 @@ class Config:
             return getattr(self, section)
         except AttributeError as e:
             print e
+
+
+console_output = {}
+console_output['filename'] = False

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -27,7 +27,7 @@ from viper.core.project import __project__
 from viper.core.plugins import __modules__
 from viper.core.database import Database
 from viper.core.storage import store_sample, get_sample_path
-from viper.core.config import Config
+from viper.core.config import Config, console_output
 from viper.common.autorun import autorun_module
 
 cfg = Config()
@@ -74,10 +74,8 @@ class Commands(object):
             type=event_type,
             data=event_data
         ))
-        if event_type == 'table':
-            print table(event_data['header'], event_data['rows'])
-        else:
-            getattr(out, 'print_{0}'.format(event_type))(event_data)
+        out.print_output([{'type': event_type, 'data': event_data}], console_output['filename'])
+
 
     ##
     # CLEAR

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -8,14 +8,14 @@ import atexit
 import readline
 import traceback
 
-from viper.common.out import print_error
+from viper.common.out import print_error, print_output
 from viper.common.colors import cyan, magenta, white, bold, blue
 from viper.core.session import __sessions__
 from viper.core.plugins import __modules__
 from viper.core.project import __project__
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
-from viper.core.config import Config
+from viper.core.config import Config, console_output
 
 cfg = Config()
 
@@ -184,9 +184,10 @@ class Console(object):
 
                 # Check for output redirection
                 # If there is a > in the string, we assume the user wants to output to file.
-                filename = False
                 if '>' in data:
-                    data, filename = data.split('>')
+                    data, console_output['filename'] = data.split('>')
+                    print("Writing output to {0}".format(console_output['filename'].strip()))
+
 
                 # If the input starts with an exclamation mark, we treat the
                 # input as a bash command and execute it.
@@ -242,3 +243,5 @@ class Console(object):
                     except Exception:
                         print_error("The command {0} raised an exception:".format(bold(root)))
                         traceback.print_exc()
+
+                console_output['filename'] = None   # reset output to stdout


### PR DESCRIPTION
This PR resolves the output redirection to file that was broken.

The big challenge is to pass the filename variable to the final function generating the output. The python recommendation of using a module as Singleton was followed. [More info](https://docs.python.org/2.7/faq/programming.html#how-do-i-share-global-variables-across-modules)

Also, the `abstracts.py` and `commands.py` used direct calls to functions in `out.py`, however this module already contained a `print_output` function containing the needed logic. 
