### PR TITLE
Fixed issue #466 http status codes / responses incorrect

### DIFF
--- a/viper-api
+++ b/viper-api
@@ -193,7 +193,11 @@ def delete_file(file_hash):
         response.code = 404
         return {'message': 'File not found in file system'}
     else:
-        success = os.remove(path)
+        try:
+            os.remove(path)
+            success = True
+        except OSError:
+            success = False
 
     if success:
         return {'message': 'deleted'}


### PR DESCRIPTION
When deleting an existing file from the repository using the API, the response object returns "Unable to delete file." even when the file is deleted successfully.

The success variable was being set to the return of the os.remove function, which always made the variable empty.  I wrapped the deletion logic into a try/except statement.

