### PR TITLE
implement Archiver class to handle (un)zipping of archives

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.
+
+import pytest
+import tempfile
+import os
+import shutil
+
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'viper-test-files/test_files',)
+
+
+@pytest.fixture()
+def cleandir():
+    newpath = tempfile.mkdtemp(prefix="viper_tests_tmp_")
+    os.chdir(newpath)
+    yield
+    shutil.rmtree(newpath)

--- a/tests/core/test_archiver.py
+++ b/tests/core/test_archiver.py
@@ -1,0 +1,417 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.
+from __future__ import unicode_literals
+
+import os
+import re
+import sys
+import shutil
+
+import pytest
+from tests.conftest import FIXTURE_DIR
+
+import subprocess
+from collections import KeysView
+
+from viper.core.archiver import Archiver, Compressor, Extractor
+from viper.core.archiver import ZipExtractor
+
+
+class TestUseCases:
+
+    def teardown_method(self):
+        pass
+
+
+class TestArchiver:
+    def test_init(self):
+        instance = Archiver()
+        assert isinstance(instance, Archiver)
+
+    def test_check_min_python_version_fail(self):
+        instance = Archiver()
+        assert isinstance(instance, Archiver)
+        instance.min_python_version = (9, 9)
+        assert instance.check() is False
+
+    def test_check_dependencies_python_fail(self):
+        instance = Archiver()
+        assert isinstance(instance, Archiver)
+        instance.dependency_list_python = ["thismoduleisnotinstalled"]
+        assert instance.check() is False
+
+    def test_check_dependencies_python_version_fail(self):
+        instance = Archiver()
+        assert isinstance(instance, Archiver)
+        instance.dependency_list_python = ["pytest>=999.0"]
+        assert instance.check() is False
+
+    def test_check_dependencies_system_fail(self):
+        instance = Archiver()
+        assert isinstance(instance, Archiver)
+        instance.dependency_list_system = ["thisbinaryisnotinstalled"]
+        assert instance.check() is False
+
+
+class TestExtractor:
+    def test_init(self):
+        instance = Extractor()
+        assert isinstance(instance, Extractor)
+        assert isinstance(instance.extractors_by_extension, dict)
+        assert isinstance(instance.extensions, (list, KeysView))
+        assert "zip" in instance.extensions
+        assert "bz2" in instance.extensions
+        assert isinstance(instance.extractors, dict)
+        assert "ZipExtractor" in instance.extractors
+        assert isinstance(instance.extractors["ZipExtractor"], ZipExtractor)
+        assert isinstance(instance.extractors["ZipExtractor"].summary, dict)
+        assert instance.extractors["ZipExtractor"].summary["cls_name"] == 'ZipExtractor'
+        assert instance.extractors["ZipExtractor"].summary["extensions"] == ['zip']
+        assert instance.extractors["ZipExtractor"].summary["password"] is True
+        assert instance.extractors["ZipExtractor"].summary["title"] == "Zip"
+        assert isinstance(instance.extractors_by_extension, dict)
+        assert isinstance(instance.extractors_by_extension["zip"], list)
+
+    @pytest.mark.usefixtures("cleandir")
+    def test_archive_does_not_exist(self, capsys):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path="/foobar97839872")
+        assert res is False
+        assert re.search("file does not exist", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", [
+        "archiver/Mac.zip",
+        "archiver/Mac.pdf.gz",
+        "archiver/Mac.pdf.bz2",
+        "archiver/Mac.tar",
+        "archiver/Mac.tar.gz",
+        "archiver/Mac.rar",
+        "archiver/Mac.7z"
+    ])
+    def test_extract(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['Mac.pdf']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename,rename_to", [
+        ("archiver/Mac.zip", "Mäc.zip"),
+        ("archiver/Mac.zip", "Mäc space Beth.zip"),
+        ("archiver/Mac.zip", "Mäc foo , bar ! - áß.zip"),
+        ("archiver/Mac.tar", "Mäc.tar"),
+        ("archiver/Mac.tar.gz", "Mäc.tar.gz"),
+        ("archiver/Mac.rar", "Mäc.rar"),
+        ("archiver/Mac.7z", "Mäc.7z"),
+    ])
+    def test_extract_input_file_special_chars(self, capsys, filename, rename_to):
+        assert os.listdir(os.getcwd()) == []
+        shutil.copy(os.path.join(FIXTURE_DIR, filename), rename_to)
+        if sys.version_info < (3, 0):  # py2
+            pass  # not working
+        else:  # py3+
+            assert os.listdir(os.getcwd()) == [rename_to]
+        instance = Extractor()
+        res = instance.extract(archive_path=rename_to, output_dir=".")
+        assert res is True
+        assert instance.err is None
+        assert len(os.listdir(os.getcwd())) == 2
+        assert 'Mac.pdf' in os.listdir(os.getcwd())
+        if sys.version_info < (3, 0):  # py2
+            pass  # not working
+        else:  # py3+
+            assert rename_to in os.listdir(os.getcwd())
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.zip"])
+    def test_extract_tmp(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename))
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == []
+        assert os.listdir(instance.output_path) == ['Mac.pdf']
+        assert os.path.dirname(instance.output_path).startswith("/tmp")
+        shutil.rmtree(instance.output_path)
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.zip"])
+    def test_extract_given_dir(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir="./foobar")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ["foobar"]
+        assert os.listdir(instance.output_path) == ['Mac.pdf']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", [
+        "archiver/Mac.pw_infected.zip",
+        "archiver/Mac.pw_infected.rar",
+        "archiver/Mac.pw_infected.7z",
+    ])
+    def test_extract_password(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".", password="infected")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['Mac.pdf']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", [
+        "archiver/Mac.pw_infected.zip",
+        "archiver/Mac.pw_infected.rar",
+        "archiver/Mac.pw_infected.7z",
+    ])
+    def test_extract_password_exclamation_fail(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".", password="!_infected_!")
+        assert res is False
+        assert pytest.raises(subprocess.CalledProcessError)
+        assert instance.err is not None
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", [
+        "archiver/Mac.pw_infected.zip",
+        "archiver/Mac.pw_infected.rar",
+        "archiver/Mac.pw_infected.7z",
+    ])
+    def test_extract_password_umlaut_fail(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        # this requires from __future__ import unicode_literals on Python2 !
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".", password="infäcted")
+        assert res is False
+        assert instance.err is not None
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.tbz2"])
+    def test_specified_cls_name(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".", cls_name="TarExtractor")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['Mac.pdf']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.tbz2"])
+    def test_specified_cls_name_does_not_exist(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".", cls_name="ThisDoesNotExistExtractor")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("invalid Extractor", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac"])
+    def test_file_without_extension(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("invalid archive_path", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", [
+        "archiver/Mac.unknown",
+    ])
+    def test_file_with_unknown_extension(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Extractor()
+        res = instance.extract(archive_path=os.path.join(FIXTURE_DIR, filename), output_dir=".")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("invalid archive_path", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+
+class TestCompressor:
+    def test_init(self):
+        instance = Compressor()
+        assert isinstance(instance, Compressor)
+        assert isinstance(instance.compressors_by_extension, dict)
+        assert isinstance(instance.extensions, (list, KeysView))
+        assert "zip" in instance.extensions
+
+    # TODO(frennkie) add tests for correct archive structure (e.g. compress file, uncompress and check dir layout)
+
+    @pytest.mark.usefixtures("cleandir")
+    def test_file_path_list_item_does_not_exist(self, capsys):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path="/foobar2783987")
+        assert res is False
+        assert re.search("file does not exist", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_compress_to_tmp(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename))
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == []
+        out_dir, out_file = os.path.split(instance.output_archive_path)
+        assert out_file == 'export.zip'
+        assert out_dir.startswith("/tmp")
+        shutil.rmtree(out_dir)
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_compress(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['export.zip']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_compress_new_dir(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./barfoo/")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['barfoo']
+        assert instance.output_archive_path == "./barfoo/export.zip"
+        assert os.listdir(os.path.dirname(instance.output_archive_path)) == ['export.zip']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./", cls_name="ZipCompressor")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['export.zip']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.tbz2"])
+    def test_specified_cls_name_does_not_exist(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./", cls_name="ThisDoesNotExistCompressor")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("invalid Compressor.*ThisDoesNotExistCompressor", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name_zip(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./", cls_name="ZipCompressor")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.path.dirname(instance.output_archive_path)) == ['export.zip']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_archive_no_extension(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./foo")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("unable to discover extension", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_archive_no_extension2(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./foo", cls_name="ZipCompressor")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ["foo.zip"]
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name_7z(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./test.7z",
+                                cls_name="SevenZipSystemCompressor")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['test.7z']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name_7z_pw(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./test_pw.7z",
+                                cls_name="SevenZipSystemCompressor", password="infected")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['test_pw.7z']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name_7z_pw_dot(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./test.pw.7z",
+                                cls_name="SevenZipSystemCompressor", password="infected")
+        assert res is True
+        assert instance.err is None
+        assert os.listdir(os.getcwd()) == ['test.pw.7z']
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_specified_cls_name_pw_provided_but_not_supported(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./test.pw.7z",
+                                cls_name="ZipCompressor", password="infected")
+        assert res is False
+        assert os.listdir(os.getcwd()) == []
+
+    @pytest.mark.usefixtures("cleandir")
+    @pytest.mark.parametrize("filename", ["archiver/Mac.pdf"])
+    def test_file_without_extension(self, capsys, filename):
+        assert os.listdir(os.getcwd()) == []
+        instance = Compressor()
+        res = instance.compress(file_path=os.path.join(FIXTURE_DIR, filename), archive_path="./test_compress")
+        assert res is False
+        assert instance.err is not None
+        assert re.search("unable to discover extension", instance.err)
+        assert os.listdir(os.getcwd()) == []
+
+    # @pytest.mark.parametrize("filename", ["Mac.pdf"])
+    # def test_meta(self, capsys, filename):
+    #     __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+    #     instance = office.Office()
+    #     instance.command_line = ["-m"]
+    #
+    #     instance.run()
+    #     out, err = capsys.readouterr()
+    #
+    #     assert re.search(r".*comments .*| htsgraghtfgyrwthwwb*", out)
+    #     assert re.search(r".*create_time .*| 2017-03-08 16:00:00*", out)
+    #     assert re.search(r".*last_saved_time .*| 2017-04-09 19:03:00.*", out)

--- a/viper/core/archiver.py
+++ b/viper/core/archiver.py
@@ -1,0 +1,743 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.
+
+import os
+import re
+import sys
+import inspect
+from distutils.spawn import find_executable
+import pkg_resources
+import logging
+
+# Compression
+import tarfile
+import zipfile
+import gzip
+import bz2
+
+import tempfile
+import shutil
+
+import subprocess
+
+log = logging.getLogger('viper')
+
+
+class Archiver(object):
+    """Archiver Class"""
+
+    title = None
+    min_python_version = (2, 7)
+    dependency_list_python = []
+    dependency_list_system = []
+    supports_extensions = []
+    supports_password = False
+
+    @property
+    def cls_name(self):
+        return self.__class__.__name__
+
+    @property
+    def summary(self):
+        return {"cls_name": self.cls_name,
+                "title": self.title,
+                "extensions": self.supports_extensions,
+                "password": self.supports_password}
+
+    def _is_subclass(self, obj):
+        return inspect.isclass(obj) and issubclass(obj, self.__class__)
+
+    def get_subclasses(self):
+        """Yields all subclasses of this class"""
+        for name, obj in inspect.getmembers(sys.modules[__name__], predicate=self._is_subclass):
+            if hasattr(obj, "__bases__") and self.__class__ in obj.__bases__:
+                yield obj
+
+    def check(self):
+        min_python_version = self._check_min_python_version()
+        dep_python = self._check_dependencies_python()
+        dep_system = self._check_dependencies_system()
+        if min_python_version and dep_python and dep_system:
+            return True
+        else:
+            return False
+
+    def _check_min_python_version(self):
+        if sys.version_info >= self.min_python_version:
+            log.debug("{}: Python Version ok".format(self.__class__.__name__))
+            return True
+        else:
+            log.warning("{}: Python Version NOT ok".format(self.__class__.__name__))
+            return False
+
+    def _check_dependencies_python(self):
+        if not self.dependency_list_python:
+            return True
+
+        missing = []
+
+        for item in self.dependency_list_python:
+            try:
+                pkg_resources.require(item)
+            except pkg_resources.DistributionNotFound as err:
+                log.debug("{}: Missing Python dependency: {}".format(self.__class__.__name__, err))
+                missing.append(item)
+            except pkg_resources.VersionConflict as err:
+                log.debug("{}: Python dependency wrong version: {}".format(self.__class__.__name__, err))
+                missing.append(item)
+
+        if missing:
+            log.warning("{}: Missing/Failed Python dependencies: {}".format(self.__class__.__name__, missing))
+            return False
+
+        return True
+
+    def _check_dependencies_system(self):
+        if not self.dependency_list_system:
+            return True
+
+        missing = [item for item in self.dependency_list_system if not find_executable(item)]
+
+        if missing:
+            log.warning("{}: Missing System dependencies: {}".format(self.__class__.__name__, missing))
+            return False
+        else:
+            return True
+
+    @staticmethod
+    def _splitext(file_name):
+        for ext in ['.tar.gz', '.tar.bz2']:
+            if file_name.endswith(ext):
+                return file_name[:-len(ext)], file_name[-len(ext):]
+        return os.path.splitext(file_name)
+
+    def auto_discover_ext(self, file_path):
+        """discover the extension (to get type of extraction/compression) from file name"""
+        name, ext = self._splitext(os.path.basename(file_path))
+        return name, ext.lstrip(".")
+
+
+# Generic Extractor class
+class Extractor(Archiver):
+    """Extractor class"""
+
+    # auto generated dict that maps extensions to subclass implementations
+    extractors = {}
+    extractors_by_extension = {}
+
+    err = None
+
+    def __init__(self, *args, **kwargs):
+        super(Extractor, self).__init__()
+
+        # path of file to extract or file/dir to compress
+        self._input_path = None
+        # path of file or directory to extract to or where to stored compressed archive
+        self._output_path = None
+
+        self.get_supported_extensions()
+
+    def get_supported_extensions(self):
+        for item in self.get_subclasses():
+            instance = item()
+            if instance.check():
+                for ext in instance.supports_extensions:
+                    self.extractors.update({instance.cls_name: instance})
+                    try:
+                        self.extractors_by_extension[ext].append(instance)
+                    except KeyError:
+                        self.extractors_by_extension[ext] = [instance]
+
+    @property
+    def extensions(self):
+        return self.extractors_by_extension.keys()
+
+    @property
+    def input_path(self):
+        return self._input_path
+
+    @input_path.setter
+    def input_path(self, value):
+        self._input_path = value
+
+    @property
+    def output_path(self):
+        return self._output_path
+
+    @output_path.setter
+    def output_path(self, value):
+        self._output_path = value
+
+    def extract(self, archive_path, output_dir=None, cls_name=None, password=None, **kwargs):
+        """Method for extracting an archive file (e.g. zip, tar, tar.gz, 7z)
+
+        :param archive_path: absolute path to file to extract
+        :type archive_path: str
+        :param output_dir: **optional** absolute path to directory to extract to
+        :type output_dir: str
+        :param cls_name: name of Extractor/Compressor class to use
+        :type cls_name: str
+        :param password: **optional** password to use
+        :type password: str
+        :param kwargs: keyword arguments (e.g for special flags)
+        :returns True if successful, otherwise False
+
+        """
+
+        if not os.path.isfile(archive_path):
+            self.err = "invalid archive_path (file does not exist): {}".format(archive_path)
+            log.error(self.err)
+            return False
+
+        if output_dir:
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir)
+                log.debug("creating output directory: {}".format(output_dir))
+        else:
+            output_dir = tempfile.mkdtemp(prefix="viper_tmp_")
+            log.debug("created output directory: {}".format(output_dir))
+
+        if cls_name:
+            log.debug("Extractor specified by caller")
+            try:
+                sub = self.extractors[cls_name]
+            except KeyError:
+                self.err = "invalid Extractor: {}. Check for missing dependencies.".format(cls_name)
+                log.error(self.err)
+                return False
+
+        else:
+            _, ext = self.auto_discover_ext(archive_path)
+            if not ext:
+                self.err = "unable to discover extension"
+                log.error(self.err)
+                return False
+
+            try:
+                sub = self.extractors_by_extension[ext][0]  # default to first
+                if password:  # try to find one that supports pw
+                    for item in self.extractors_by_extension[ext]:
+                        if item.supports_password:
+                            sub = item
+                            break
+                        else:
+                            sub = self.extractors_by_extension[ext][0]  # try first anyway
+
+            except KeyError:
+                self.err = "no available Extractor supports extension: {}. Check for missing dependencies.".format(cls_name)
+                log.error(self.err)
+                return False
+
+        sub.input_path = archive_path
+        sub.output_path = output_dir
+
+        if sub.supports_password:
+            ret = sub.run(password=password, **kwargs)
+        else:
+            ret = sub.run(**kwargs)
+
+        if ret:
+            self.output_path = sub.output_path
+            log.debug(self.output_path)
+            return True
+        else:
+            self.err = sub.err
+            log.error(self.err)
+            return False
+
+
+# Extractor implementations
+class ZipExtractor(Extractor):
+    """Zip"""
+
+    title = "Zip"
+    supports_extensions = ["zip"]
+    supports_password = True
+
+    def run(self, password=None, **kwargs):
+        log.info("Extract: {}".format(self.title))
+
+        if password:
+            try:
+                password = password.encode('ascii')  # py3 requires bytes (not str)
+            except UnicodeEncodeError as err:
+                log.error("Extract ({}) failed. Password only supports ascii characters: {}".format(self.title, err))
+                self.err = err
+                return False
+
+        try:
+            with zipfile.ZipFile(self.input_path) as zf:
+                zf.extractall(self.output_path, pwd=password)
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            if "password" in err.__repr__():
+                log.warning("Password either missing or incorrect!")
+            self.err = err
+            return False
+
+        return True
+
+
+class GZipExtractor(Extractor):
+    """GZip"""
+
+    title = "GZip"
+    supports_extensions = ["gz"]
+
+    # need to override output_path setter as we want to tell GZip to which file to extract to (instead of a directory)
+    @property
+    def output_path(self):
+        return self._output_path
+
+    @output_path.setter
+    def output_path(self, value):
+        base_name, _ = os.path.splitext(os.path.basename(self.input_path))
+        self._output_path = os.path.join(value, base_name)
+
+    def run(self, **kwargs):
+        log.info("Extract: {}".format(self.title))
+
+        try:
+            with gzip.GzipFile(self.input_path, 'rb') as zf:
+                decompressed = zf.read()
+
+            with open(self.output_path, "wb") as df:
+                df.write(decompressed)
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        return True
+
+
+class BZ2Extractor(Extractor):
+    """BZip2"""
+
+    title = "BZip2"
+    supports_extensions = ["bz2"]
+
+    # need to override output_path setter as we want to tell BZip2 to which file to extract to (instead of a directory)
+    @property
+    def output_path(self):
+        return self._output_path
+
+    @output_path.setter
+    def output_path(self, value):
+        base_name, _ = os.path.splitext(os.path.basename(self.input_path))
+        self._output_path = os.path.join(value, base_name)
+
+    def run(self, **kwargs):
+        log.info("Extract: {}".format(self.title))
+
+        try:
+            with bz2.BZ2File(self.input_path, 'rb') as zf:
+                decompressed = zf.read()
+
+            with open(self.output_path, "wb") as df:
+                df.write(decompressed)
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        return True
+
+
+class TarExtractor(Extractor):
+    """Tar"""
+
+    title = "Tar"
+    supports_extensions = ["tar", "tar.gz", "tar.bz2"]
+
+    def run(self, **kwargs):
+        log.info("Extract: {} (or tar.gz/tar.bz2)".format(self.title))
+
+        if not tarfile.is_tarfile(self.input_path):
+            self.err = "This is not a tar file"
+            log.error(self.err)
+            return False
+
+        try:
+            with tarfile.open(self.input_path, 'r:*') as tarf:
+                tarf.extractall(self.output_path)
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        return True
+
+
+class RarExtractor(Extractor):
+    """RAR"""
+
+    title = "Rar"
+    dependency_list_python = ["rarfile"]
+    dependency_list_system = ["unrar"]
+    supports_extensions = ["rar"]
+    supports_password = True
+
+    def run(self, password=None, **kwargs):
+        log.info("Extract: {}".format(self.title))
+        import rarfile
+
+        try:
+            with rarfile.RarFile(self.input_path) as rf:
+                rf.extractall(self.output_path, pwd=password)
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        return True
+
+
+class SevenZipSystemExtractor(Extractor):
+    """7-Zip"""
+
+    title = "7-Zip (System)"
+    dependency_list_system = ["7z"]
+    supports_extensions = ["7z"]
+    supports_password = True
+
+    def run(self, password=None, **kwargs):
+        log.info("Extract: {}".format(self.title))
+
+        tmp_dir = tempfile.mkdtemp(prefix="viper_tmp_")
+
+        try:
+            out = "-o{}".format(tmp_dir)
+            if password:
+                pwd = "-p{}".format(password)
+                res = subprocess.check_output(["7z", "x", out, "-r", "-y", pwd, self.input_path], stderr=subprocess.STDOUT)
+            else:
+                res = subprocess.check_output(["7z", "x", out, "-r", "-y", self.input_path], stderr=subprocess.STDOUT)
+
+            for item in os.listdir(tmp_dir):
+                shutil.move(os.path.join(tmp_dir, item), self.output_path)
+
+        except subprocess.CalledProcessError as err:
+            log.error("Running shell command \"{}\" caused error: {} (RC: {}".format(err.cmd, err.output, err.returncode))
+            self.err = err
+
+            lines = err.output.decode("utf-8")
+            for line in lines.split("\n"):
+                if re.search("password", line.lower()):
+                    log.warning("Password either missing or incorrect!")
+
+            return False
+
+        except Exception as err:
+            log.error("Extract ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        finally:
+            shutil.rmtree(tmp_dir)
+
+        return True
+
+
+# Generic Compressor class
+class Compressor(Archiver):
+    """Compressor class"""
+
+    # auto generated dict that maps extensions to subclass implementations
+    compressors = {}
+    compressors_by_extension = {}
+
+    err = None
+
+    def __init__(self, *args, **kwargs):
+        super(Compressor, self).__init__()
+
+        # default basename for compressed files
+        self.default_basename = "export"
+        # default extension
+        self.default_ext = "zip"
+
+        # list of tuples each containing:
+        # * 1) path to file or directory to compress
+        # * 2) name of the compressed file in the archive
+        self._input_tuple_list = None
+
+        # path where to store compressed archive (full path - e.g. /tmp/files/sample.zip)
+        self._output_archive_path = None
+        # name compressed archive (name only - e.g. sample.zip)
+        self._output_archive_name = None
+        # basename of archive (name only - e.g. sample)
+        self._output_archive_basename = None
+        # extension of archive (name only - e.g. zip)
+        self._output_archive_ext = None
+
+        self.get_supported_extensions()
+
+    def get_supported_extensions(self):
+        for item in self.get_subclasses():
+            instance = item()
+            if instance.check():
+                for ext in instance.supports_extensions:
+                    self.compressors.update({instance.cls_name: instance})
+                    try:
+                        self.compressors_by_extension[ext].append(instance)
+                    except KeyError:
+                        self.compressors_by_extension[ext] = [instance]
+
+    @property
+    def extensions(self):
+        return self.compressors_by_extension.keys()
+
+    @property
+    def input_tuple_list(self):
+        return self._input_tuple_list
+
+    @input_tuple_list.setter
+    def input_tuple_list(self, value):
+        self._input_tuple_list = value
+
+    @property
+    def output_archive_path(self):
+        return self._output_archive_path
+
+    @output_archive_path.setter
+    def output_archive_path(self, value):
+        self._output_archive_path = value
+
+    @property
+    def output_archive_name(self):
+        return self._output_archive_name
+
+    @output_archive_name.setter
+    def output_archive_name(self, value):
+        self._output_archive_name = value
+
+    @property
+    def output_archive_basename(self):
+        return self._output_archive_basename
+
+    @output_archive_basename.setter
+    def output_archive_basename(self, value):
+        self._output_archive_basename = value
+
+    @property
+    def output_archive_ext(self):
+        return self._output_archive_ext
+
+    @output_archive_ext.setter
+    def output_archive_ext(self, value):
+        self._output_archive_ext = value
+
+    def compress(self, file_path, file_name=None, archive_path=None, cls_name=None, password=None, **kwargs):
+        """compress one file into an archive (e.g. zip, tar, tar.gz, 7z)
+
+        :param file_path: path to file to compress
+        :type file_path: str
+        :param file_name: name of file in archive (defaults to retrieving name from file_path)
+        :type file_name: str
+        :param archive_path: **optional** full path to archive (e.g. "/tmp/sample51.zip")
+        :type archive_path: str
+        :param cls_name: **optional** name of Compressor class to use
+        :type cls_name: str
+        :param password: **optional** password to use
+        :type password: str
+        :param kwargs: keyword arguments (e.g for special flags)
+        :returns True if successful, otherwise False
+
+        """
+
+        if not os.path.isfile(file_path):
+            self.err = "invalid file_path (file does not exist): {}".format(file_path)
+            log.error(self.err)
+            return False
+
+        if not file_name:
+            _, file_name = os.path.split(file_path)
+
+        archive_basename = None
+        archive_ext = self.default_ext  # if no other extension can be determined then default to zip
+
+        if not archive_path:
+            archive_dir = tempfile.mkdtemp(prefix="viper_tmp_")
+            log.debug("created output directory: {}".format(archive_dir))
+        else:
+            archive_dir, archive_name = os.path.split(archive_path)
+            if archive_name:
+                archive_basename, archive_ext = self.auto_discover_ext(archive_name)
+
+            if not os.path.exists(archive_dir):
+                os.makedirs(archive_dir)
+                log.debug("created output directory: {}".format(archive_dir))
+
+        if cls_name:  # try to get specified sub class by provided name
+            log.debug("Compressor specified by caller")
+            try:
+                sub = self.compressors[cls_name]
+            except KeyError:
+                self.err = "invalid Compressor: {} (check for missing dependencies)".format(cls_name)
+                log.error(self.err)
+                return False
+
+            if not archive_path:
+                archive_ext = sub.supports_extensions[0]
+
+        else:
+            # class not provided - try to determine class by file extension
+            if archive_basename:
+                _, _res_auto_discover_ext = self.auto_discover_ext(archive_basename)
+                if not _res_auto_discover_ext:
+                    self.err = "unable to discover extension"
+                    log.error(self.err)
+                    return False
+                else:
+                    archive_ext = _res_auto_discover_ext
+
+            try:
+                sub = self.compressors_by_extension[archive_ext][0]  # default to first
+                if password:  # try to find one that supports pw
+                    for item in self.compressors_by_extension[archive_ext]:
+                        if item.supports_password:
+                            sub = item
+                            break
+                        else:
+                            sub = self.compressors_by_extension[archive_ext][0]  # try first anyway
+
+            except KeyError:
+                self.err = "no available Extractor supports extension: {} (check for missing dependencies)".format(cls_name)
+                log.error(self.err)
+                return False
+
+        if not archive_basename:
+            archive_basename = self.default_basename
+
+        if archive_ext:
+            if archive_ext in sub.supports_extensions:  # e.g. for ZipCompressor file.zip stays file.zip
+                archive_name = "{}.{}".format(archive_basename, archive_ext)
+            else:   # e.g. file.exe will become file.exe.zip
+                archive_name = "{}.{}.{}".format(archive_basename, archive_ext, sub.supports_extensions[0])
+        else:  # e.g. file will become file.zip
+            archive_name = "{}.{}".format(archive_basename, sub.supports_extensions[0])
+
+        output_path = os.path.join(archive_dir, archive_name)
+
+        if os.path.isfile(output_path):
+            self.err = "file exists - will not overwrite: {}".format(output_path)
+            log.error(self.err)
+            return False
+
+        sub.input_tuple_list = [(file_path, file_name)]
+
+        sub.output_archive_path = output_path
+        sub.output_archive_name = archive_name
+        sub.output_archive_basename, sub.output_archive_ext = self.auto_discover_ext(archive_name)
+
+        if password and not sub.supports_password:
+            self.err = "password provided but modules does not support encryption: {}".format(sub.cls_name)
+            log.error(self.err)
+            return False
+
+        if sub.supports_password:
+            ret = sub.run(password=password, **kwargs)
+        else:
+            ret = sub.run(**kwargs)
+
+        if ret:
+            self.output_archive_path = sub.output_archive_path
+            log.info(self.output_archive_path)
+            return True
+        else:
+            self.err = sub.err
+            log.error(self.err)
+            return False
+
+# All Compressor implementations MUST take a list of tuples as input.
+# The list represents multiple files that MUST be compressed into one archive.
+# The tuples specify for each file the path on disk to a file and the path
+# that this file MUST have in the archive.
+# The path of the compressed files within the archive MUST be prepended by
+# basename of the archive.
+#
+# Example:
+#   Archive name is: sample.zip
+#
+#   self.output_archive_path is /tmp/exports/sample.zip
+#   self.input_tuple_list = [("/tmp/eggs", "eggs"), ("/tmp/spam/foo.txt", "foobar/spam_foo.txt")]
+#
+#   The resulting archive MUST - when extracted - generate two files (relative to local dir):
+#   * ./sample/eggs
+#   * ./sample/foobar/spam_foo.txt
+#
+# Reminder: Do not leave behind artifacts (e.g. temporary files or directories)
+
+
+# Compressor implementations
+class ZipCompressor(Compressor):
+    """Zip"""
+
+    title = "Zip"
+    supports_extensions = ["zip"]
+
+    def run(self, **kwargs):
+        log.info("Compress: {}".format(self.title))
+
+        try:
+            with zipfile.ZipFile(self.output_archive_path, 'w') as zf:
+                for item_path, item_name in self.input_tuple_list:
+                    zf.write(item_path, arcname=os.path.join(self.output_archive_basename, item_name))
+
+        except Exception as err:
+            log.error("Compress ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        return True
+
+
+class SevenZipSystemCompressor(Compressor):
+    """7-Zip"""
+
+    title = "7-Zip (System)"
+    dependency_list_system = ["7z"]
+    supports_extensions = ["7z"]
+    supports_password = True
+
+    def run(self, password=None, **kwargs):
+        log.info("Compress: {}".format(self.title))
+
+        tmp_dir = tempfile.mkdtemp(prefix="viper_tmp_")
+        archive_sub_dir = os.path.join(tmp_dir, self.output_archive_basename)
+        os.mkdir(archive_sub_dir)
+
+        for item_path, item_name in self.input_tuple_list:
+            shutil.copyfile(item_path, os.path.join(archive_sub_dir, item_name))
+
+        try:
+            if password:
+                pwd = "-p{}".format(password)
+                res = subprocess.check_output(["7z", "a", pwd, "-y", self.output_archive_path, "-w", archive_sub_dir], stderr=subprocess.STDOUT)
+            else:
+                res = subprocess.check_output(["7z", "a", "-y", self.output_archive_path, "-w", archive_sub_dir], stderr=subprocess.STDOUT)
+            log.debug("Result: {}".format(res))
+
+        except subprocess.CalledProcessError as err:
+            log.debug("Running shell command \"{}\" caused error: {} (RC: {}".format(err.cmd, err.output, err.returncode))
+            self.err = err
+            os.remove(self.output_archive_path)
+            return False
+
+        except Exception as err:
+            log.error("Compress ({}) failed. Error: {}".format(self.title, err))
+            self.err = err
+            return False
+
+        finally:
+            # this also runs if an Exception occurs: make sure that temp dir is deleted
+            shutil.rmtree(tmp_dir)
+
+        return True

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of Viper - https://github.com/viper-framework/viper
 # See the file 'LICENSE' for copying permission.
 
@@ -7,6 +8,7 @@ import time
 import json
 import shutil
 import fnmatch
+import getpass
 import tempfile
 import argparse
 from zipfile import ZipFile
@@ -30,6 +32,7 @@ from viper.core.database import Database
 from viper.core.storage import store_sample, get_sample_path
 from viper.core.config import Config, console_output
 from viper.common.autorun import autorun_module
+from viper.core.archiver import Compressor
 
 cfg = Config()
 
@@ -38,6 +41,22 @@ try:
     input = raw_input
 except NameError:
     pass
+
+
+def get_password_once():
+    password = getpass.getpass('Password: ')
+    if password:
+        return password
+    else:
+        return False
+
+
+def get_password_twice():
+    password = getpass.getpass('Password: ')
+    if password == getpass.getpass('confirm Password: '):
+        return password
+    else:
+        return False
 
 
 class Commands(object):
@@ -839,7 +858,9 @@ class Commands(object):
     # This command will export the current session to file or zip.
     def cmd_export(self, *args):
         parser = argparse.ArgumentParser(prog='export', description="Export the current session to file or zip")
-        parser.add_argument('-z', '--zip', action='store_true', help="Export session in a zip archive")
+        parser.add_argument('-z', '--zip', action='store_true', help="Export session in a zip archive (PW support: No)")
+        parser.add_argument('-7', '--sevenzip', action='store_true', help="Export session in a 7z archive (PW support: Yes)")
+        parser.add_argument('-p', '--password', action='store_true', help="Protect archive with a password (PW) if supported")
         parser.add_argument('value', help="path or archive name")
 
         try:
@@ -858,29 +879,23 @@ class Commands(object):
             parser.print_usage()
             return
 
-        # TODO: having for one a folder and for the other a full
-        # target path can be confusing. We should perhaps standardize this.
+        if args.zip and args.sevenzip:
+            self.log('error', "Please select either -z or -7 not both, abort")
 
-        # Abort if the specified path already exists.
-        if os.path.isfile(args.value):
-            self.log('error', "File at path \"{0}\" already exists, abort".format(args.value))
-            return
+        store_path = os.path.join(args.value, __sessions__.current.file.name)
 
-        # If the argument chosed so, archive the file when exporting it.
-        # TODO: perhaps add an option to use a password for the archive
-        # and default it to "infected".
-        if args.zip:
-            try:
-                with ZipFile(args.value, 'w') as export_zip:
-                    export_zip.write(__sessions__.current.file.path, arcname=__sessions__.current.file.name)
-            except IOError as e:
-                self.log('error', "Unable to export file: {0}".format(e))
-            else:
-                self.log('info', "File archived and exported to {0}".format(args.value))
-        # Otherwise just dump it to the given directory.
-        else:
-            # XXX: Export file with the original file name.
-            store_path = os.path.join(args.value, __sessions__.current.file.name)
+        if not args.zip and not args.sevenzip:
+            # Abort if the specified path already exists
+            if os.path.isfile(store_path):
+                self.log('error', "File at path \"{0}\" already exists, abort".format(args.value))
+                return
+
+            if os.path.isfile(args.value):
+                self.log('error', "File at path \"{0}\" already exists, abort".format(args.value))
+                return
+
+            if not os.path.isdir(args.value):
+                os.makedirs(args.value)
 
             try:
                 shutil.copyfile(__sessions__.current.file.path, store_path)
@@ -888,6 +903,40 @@ class Commands(object):
                 self.log('error', "Unable to export file: {0}".format(e))
             else:
                 self.log('info', "File exported to {0}".format(store_path))
+
+            return
+        elif args.zip:
+            cls = "ZipCompressor"
+
+        elif args.sevenzip:
+            cls = "SevenZipSystemCompressor"
+        else:
+            cls = ""
+            self.log('error', "Not implemented".format())
+
+        c = Compressor()
+
+        if args.password:
+            if c.compressors[cls].supports_password:
+                _password = get_password_twice()
+                if not _password:
+                    self.log('error', "Passwords did not match, abort")
+                    return
+                res = c.compress(__sessions__.current.file.path, file_name=__sessions__.current.file.name,
+                                 archive_path=store_path, cls_name=cls, password=_password)
+            else:
+                self.log('warning', "ignoring password (not supported): {}".format(cls))
+                res = c.compress(__sessions__.current.file.path, file_name=__sessions__.current.file.name,
+                                 archive_path=store_path, cls_name=cls)
+
+        else:
+            res = c.compress(__sessions__.current.file.path, file_name=__sessions__.current.file.name,
+                             archive_path=store_path, cls_name=cls)
+
+        if res:
+            self.log('info', "File archived and exported to {0}".format(c.output_archive_path))
+        else:
+            self.log('error', "Unable to export file: {0}".format(c.err))
 
     ##
     # STATS


### PR DESCRIPTION
The (django) branch of the web interface has some code for decompressing an uploaded file. In my opinion it makes sense to have a backend functionality than handles compressing and extracting files. This PR adds an "Archiver" class to core and I would like to get some feedback whether others think that this makes sense too.

This PR now also adds an option to **export** to a 7z compressed archive (which can *optionally* be password protected).

```
viper cmd.exe > export -h
usage: export [-h] [-z] [-7] [-p] value

Export the current session to file or zip

positional arguments:
  value           path or archive name

optional arguments:
  -h, --help      show this help message and exit
  -z, --zip       Export session in a zip archive (PW support: No)
  -7, --sevenzip  Export session in a 7z archive (PW support: Yes)
  -p, --password  Protect archive with a password (PW) if supported
```

If this is accepted it would be pretty straightforward to add password support when adding (store/upload) files (see #474). Extracting with password to zip (#105) could also easily be added as a new Extractor sub class.

Open tasks are:
* [x] adding password support when compressing (#474)
* [x] adding password support on more extraction types (see also #105)
* [x] adding more extraction types (e.g. 7z (#342),  rar...) 