### PR TITLE
add *about* command

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+import platform
 from os.path import expanduser
 import time
 import json
@@ -23,12 +24,14 @@ from viper.common.colors import bold
 from viper.common.utils import convert_size
 from viper.common.objects import File
 from viper.common.network import download
+from viper.common.version import __version__
 from viper.core.session import __sessions__
 from viper.core.project import __project__
 from viper.core.plugins import __modules__
 from viper.core.database import Database
 from viper.core.storage import store_sample, get_sample_path
 from viper.core.config import Config, console_output
+import  viper.core.ui.console
 from viper.common.autorun import autorun_module
 
 cfg = Config()
@@ -50,6 +53,7 @@ class Commands(object):
         # Map commands to their related functions.
         self.commands = dict(
             help=dict(obj=self.cmd_help, description="Show this help message"),
+            about=dict(obj=self.cmd_about, description="Show information about this Viper instance"),
             open=dict(obj=self.cmd_open, description="Open a file"),
             new=dict(obj=self.cmd_new, description="Create new file"),
             close=dict(obj=self.cmd_close, description="Close the current session"),
@@ -110,6 +114,20 @@ class Commands(object):
         rows = sorted(rows, key=lambda entry: entry[0])
 
         self.log('table', dict(header=['Command', 'Description'], rows=rows))
+
+    ##
+    # ABOUT
+    #
+    # This command prints some useful information regarding the running
+    # Viper instance
+    def cmd_about(self, *args):
+        rows = list()
+        rows.append(["Viper Version", __version__])
+        rows.append(["Python Version", platform.python_version()])
+        rows.append(["Homepage", "https://viper.li"])
+        rows.append(["Issue Tracker", "https://github.com/viper-framework/viper/issues"])
+
+        self.log('table', dict(header=['About', ''], rows=rows))
 
     ##
     # NEW

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -132,7 +132,7 @@ class Commands(object):
         rows = list()
         rows.append(["Configuration File", cfg.config_file])
         rows.append(["Storage Path", __project__.path])
-        rows.append(["Database (default)", self.db.engine])
+        rows.append(["Current Project Database", self.db.engine])
 
         self.log('table', dict(header=['Configuration', ''], rows=rows))
 

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -129,6 +129,13 @@ class Commands(object):
 
         self.log('table', dict(header=['About', ''], rows=rows))
 
+        rows = list()
+        rows.append(["Configuration File", cfg.config_file])
+        rows.append(["Storage Path", __project__.path])
+        rows.append(["Database (default)", self.db.engine])
+
+        self.log('table', dict(header=['Configuration', ''], rows=rows))
+
     ##
     # NEW
     #


### PR DESCRIPTION
Add an **about** command that shows some useful information.
This PR is intended to start a discussion on how this should look and what should be included.

Current display:

```
viper > about
+----------------+-------------------------------------------------+
| About          |                                                 |
+----------------+-------------------------------------------------+
| Viper Version  | 1.3-dev                                         |
| Python Version | 2.7.6                                           |
| Homepage       | https://viper.li                                |
| Issue Tracker  | https://github.com/viper-framework/viper/issues |
+----------------+-------------------------------------------------+
+--------------------------+----------------------------------------------+
| Configuration            |                                              |
+--------------------------+----------------------------------------------+
| Configuration Path       | /home/user/.viper/viper.conf                 |
| Storage Path             | /home/user/.viper                            |
| Current Project Database | Engine(sqlite:////home/user/.viper/viper.db) |
+--------------------------+----------------------------------------------+
```
Will eventually fix #523.