### PR TITLE
store config_file path on object to able to access it later

### DIFF
--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -18,7 +18,7 @@ class Config:
         # use cfg as a first priority
         if cfg:
             if os.path.exists(cfg):
-                config_file = cfg
+                self.config_file = cfg
         else:
             # Possible paths for the configuration file.
             # This should go in order from local to global.
@@ -29,15 +29,15 @@ class Config:
             ]
 
             # Try to identify the best location for the config file.
-            config_file = None
+            self.config_file = None
             for config_path in config_paths:
                 if os.path.exists(config_path):
-                    config_file = config_path
+                    self.config_file = config_path
                     break
 
             # If no config is available, we try to copy it either from the
             # /usr/share/viper folder, or from VIPER_ROOT.
-            if not config_file:
+            if not self.config_file:
                 share_viper ='/usr/share/viper/viper.conf.sample'
                 cwd_viper = os.path.join(VIPER_ROOT, 'viper.conf.sample')
 
@@ -47,19 +47,19 @@ class Config:
                 if not os.path.exists(local_storage):
                     os.makedirs(local_storage)
 
-                config_file = os.path.join(local_storage, 'viper.conf')
+                self.config_file = os.path.join(local_storage, 'viper.conf')
 
 
                 if os.path.exists(share_viper):
-                    shutil.copy(share_viper, config_file)
+                    shutil.copy(share_viper, self.config_file)
                 else:
-                    shutil.copy(cwd_viper, config_file)            
+                    shutil.copy(cwd_viper, self.config_file)
 
-        # Pasre the config file.
+        # Parse the config file.
         config = ConfigParser()
-        config.read(config_file)
+        config.read(self.config_file)
 
-        # Pars ethe config file and attribute for the current instantiated
+        # Parse the config file and attribute for the current instantiated
         # object.
         for section in config.sections():
             setattr(self, section, Dictionary())


### PR DESCRIPTION
I'd like to show the path to the used config in the **about** command (see #523)