### PR TITLE
catch error when open -l receives a string instead of int

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -197,13 +197,16 @@ class Commands(object):
         # the last find command.
         elif args.last:
             if __sessions__.find:
-                count = 1
-                for item in __sessions__.find:
-                    if count == int(target):
+                try:
+                    target = int(target)
+                except ValueError:
+                    self.log('warning', "Please pass the entry number from the last find to -l/--last (e.g. open -l 5)")
+                    return
+
+                for idx, item in enumerate(__sessions__.find, start=1):
+                    if idx == target:
                         __sessions__.new(get_sample_path(item.sha256))
                         break
-
-                    count += 1
             else:
                 self.log('warning', "You haven't performed a find yet")
         # Otherwise we assume it's an hash of an previously stored sample.


### PR DESCRIPTION
If the user incorrectly provides a string to open -l / --last then and traceback is printed.
This catches the error and prints a warning.

### before
``` 
default viper > open -l foobar
[!] The command open raised an exception:
Traceback (most recent call last):
  File "/home/user/work/viper/viper/core/ui/console.py", line 236, in start
    self.cmd.commands[root]['obj'](*args)
  File "/home/user/work/viper/viper/core/ui/commands.py", line 199, in cmd_open
    if count == int(target):
ValueError: invalid literal for int() with base 10: 'foobar'
```
### after
```
viper > open -l foobar
[!] Please pass the entry number from the last find to -l/--last (e.g. open -l 5)
```