### PR TITLE
Update Analysis stored_at database settings

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -160,7 +160,7 @@ class Analysis(Base):
     id = Column(Integer(), primary_key=True)
     cmd_line = Column(String(255), nullable=True)
     results = Column(Text(), nullable=False)
-    stored_at = Column(DateTime(timezone=False), default=datetime.now(), nullable=False)
+    stored_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
 
     def to_dict(self):
         row_dict = {}

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -160,7 +160,7 @@ class Analysis(Base):
     id = Column(Integer(), primary_key=True)
     cmd_line = Column(String(255), nullable=True)
     results = Column(Text(), nullable=False)
-    stored_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    stored_at = Column(DateTime(timezone=False), default=datetime.utcnow, nullable=False)
 
     def to_dict(self):
         row_dict = {}

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -402,7 +402,7 @@ class Commands(object):
             rows = [[analysis.id, analysis.cmd_line, analysis.stored_at] for analysis in analysis_list]
 
             # Display list of existing results.
-            self.log('table', dict(header=['ID', 'Cmd Line', 'Saved On'], rows=rows))
+            self.log('table', dict(header=['ID', 'Cmd Line', 'Saved On (UTC)'], rows=rows))
 
         elif args.view:
             # Retrieve analysis wth the specified ID and print it.


### PR DESCRIPTION
Changing `datetime.now()` to `datetime.now` should fix #532 (at least it works for me).
Whether or not timestamp should be UTC (`datetime.utcnow`) or local and whether it should be timezone aware (`timezone=True` - if available) nor not is debatable.

Caution: This could have an effect on existing databases, right?