### PR TITLE
Export - update error message and catch additional case

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -896,15 +896,15 @@ class Commands(object):
         if not args.zip and not args.sevenzip:
             # Abort if the specified path already exists
             if os.path.isfile(store_path):
-                self.log('error', "File at path \"{0}\" already exists, abort".format(args.value))
-                return
-
-            if os.path.isfile(args.value):
-                self.log('error', "File at path \"{0}\" already exists, abort".format(args.value))
+                self.log('error', "Unable to export file: File exists: '{0}'".format(store_path))
                 return
 
             if not os.path.isdir(args.value):
-                os.makedirs(args.value)
+                try:
+                    os.makedirs(args.value)
+                except OSError as err:
+                    self.log('error', "Unable to export file: {0}".format(err))
+                    return
 
             try:
                 shutil.copyfile(__sessions__.current.file.path, store_path)


### PR DESCRIPTION
When the user exports a file to path that should be a directory ( e.g. `/tmp/export/` ) but there is already a file with that name an exception is shown. This PR catches this case.

### Before

```
echo "test" > /tmp/export
```

```
viper > find all; open -l 1; export /tmp/export/
[!] The command export raised an exception:
Traceback (most recent call last):
  File "/home/user/work/viper_testing/viper/viper/core/ui/console.py", line 237, in start
    self.cmd.commands[root]['obj'](*args)
  File "/home/user/work/viper_testing/viper/viper/core/ui/commands.py", line 907, in cmd_export
    os.makedirs(args.value)
  File "/home/user/work/viper_testing/python2/venv/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/tmp/export/'
```

### After
```
[...]
[*] Session opened on /home/user/.viper/binaries/1/7/f/7/17f746d82695fa9b35493b41859d39d786d32b23a9d2e00f4011dec7a02402ae
[!] Unable to export file: [Errno 17] File exists: '/tmp/export/'
```