### PR TITLE
add tab completion for projects (on switch and copy)

### DIFF
--- a/viper/core/project.py
+++ b/viper/core/project.py
@@ -68,3 +68,21 @@ class Project(object):
 
 
 __project__ = Project()
+
+
+def get_project_list(exclude_default=False):
+    """get_project_list - get list of all projects"""
+    projects_path = __project__.get_projects_path()
+    project_list = []
+    if os.path.exists(projects_path):
+        for project in os.listdir(projects_path):
+            project_path = os.path.join(projects_path, project)
+            if os.path.isdir(project_path):
+                project_list.append(project)
+
+    if exclude_default:
+        pass
+    else:
+        project_list.append("default")
+
+    return project_list

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -131,8 +131,8 @@ class Console(object):
                 if words[0] == "projects":
                     if "--switch" in words or "-s" in words:
                         options += get_project_list()
-                        
-                # enable tab completion for copy (list projects)
+
+                        # enable tab completion for copy (list projects)
                 if words[0] == "copy":
                     options += get_project_list()
 

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -17,7 +17,7 @@ from viper.common.colors import cyan, magenta, white, bold, blue
 from viper.common.version import __version__
 from viper.core.session import __sessions__
 from viper.core.plugins import __modules__
-from viper.core.project import __project__
+from viper.core.project import __project__, get_project_list
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
 from viper.core.config import Config, console_output
@@ -126,6 +126,16 @@ class Console(object):
                     fs_path_completion = True
 
                 options = [key for key in self.cmd.commands[words[0]]["parser_args"]]
+
+                # enable tab completion for projects --switch
+                if words[0] == "projects":
+                    if "--switch" in words or "-s" in words:
+                        options += get_project_list()
+                        
+                # enable tab completion for copy (list projects)
+                if words[0] == "copy":
+                    options += get_project_list()
+
                 completions = [i for i in options if i.startswith(text) and i not in words]
 
             elif words[0] in [i for i in __modules__]:


### PR DESCRIPTION
I think it would also be useful to be able to tab complete the names of existing projects (e.g. when doing `projects -s <foo>` or `copy <bar>`.

This PR add the completion options.