### PR TITLE
fix project switch

### DIFF
--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -937,11 +937,11 @@ class Projects(Command):
 
         projects_path = os.path.join(base_path, 'projects')
 
-        if not os.path.exists(projects_path):
-            self.log('info', "The projects directory does not exist yet")
-            return
-
         if args.list:
+            if not os.path.exists(projects_path):
+                self.log('info', "The projects directory does not exist yet")
+                return
+
             self.log('info', "Projects Available:")
 
             rows = []


### PR DESCRIPTION
Running the command `project -s new_project` does not work if the `$storage_path/projects` path does not exist. This PR moves the check for `projects_path` into `projects --list`. 

Now `project -s new_project` will simply create `$storage_path/projects`  and the new project dir.