### PR TITLE
Fixed python3 signature encoding confusion with `pe peid`

### DIFF
--- a/viper/modules/pe.py
+++ b/viper/modules/pe.py
@@ -313,7 +313,7 @@ class PE(Module):
             if not userdb_path:
                 return
 
-            with open(userdb_path, 'rb') as f:
+            with open(userdb_path, 'rt', encoding='ISO-8859-1') as f:
                 sig_data = f.read()
 
             signatures = peutils.SignatureDatabase(data=sig_data)


### PR DESCRIPTION
Peutil does not know the proper encoding for the opened signature file in python3. This causes a TypeError to be raised. This commit adds the proper encoding (iso-8859) to the call to open

**I have only tested this against a python3 based install of viper. I cannot confirm that this is backwards compatible.**

Here is the error that is raised.
```python
test viper 33659c92c53259e3d2f2c71e66bab762 > pe peid
[!] The command pe raised an exception:
Traceback (most recent call last):
  File "/home/viper/viper/viper/core/ui/console.py", line 318, in start
    module.run()
  File "/home/viper/viper/viper/modules/pe.py", line 1012, in run
    self.peid()
  File "/home/viper/viper/viper/modules/pe.py", line 330, in peid
    signatures = get_signatures()
  File "/home/viper/viper/viper/modules/pe.py", line 319, in get_signatures
    signatures = peutils.SignatureDatabase(data=sig_data)
  File "/usr/local/lib/python3.4/dist-packages/peutils.py", line 80, in __init__
    self.__load(filename=filename, data=data)
  File "/usr/local/lib/python3.4/dist-packages/peutils.py", line 436, in __load
    matches = self.parse_sig.findall(sig_data)
TypeError: can't use a string pattern on a bytes-like object
```

