### PR TITLE
MISP Sharing Groups, default Dist & Sharing Group in config

### DIFF
--- a/viper.conf.sample
+++ b/viper.conf.sample
@@ -83,6 +83,11 @@ misp_vturl = https://www.virustotal.com/vtapi/v2/file/report
 # To use the misp taxonomies, you need to clone https://github.com/MISP/misp-taxonomies
 # and set the path to the directory here:
 misp_taxonomies_directory = ./misp-taxonomies
+# Set the following to select default distribution and sharing group (if in use)
+# Distribution ranges from 0-4, with sharing group only set when distribution is 4.
+# Leave empty to use PyMISP default
+misp_distribution = 
+misp_sharinggroup = 
 
 [pssl]
 pssl_url =


### PR DESCRIPTION
Added further control in setting the distribution level of created events, allowing sharing group distribution to be set.
Also can add default values of sharing group and distribution in config - Code has been made backwards compatible to ensure those without the new config attributes won't get an error.