### PR TITLE
add global and per module settings for requests

### DIFF
--- a/docs/source/customize/index.rst
+++ b/docs/source/customize/index.rst
@@ -65,9 +65,9 @@ You can easily access the config file:
     .. code-block:: python
         :linenos:
 
-        from viper.core.config import Config
+        from viper.core.config import __config__
 
-        cfg = Config()
+        cfg = __config__
 
 
 From here you can access any element in the config file by name:

--- a/docs/source/customize/index.rst
+++ b/docs/source/customize/index.rst
@@ -87,6 +87,53 @@ From here you can access any element in the config file by name:
 
 
 
+Using common config settings for outbound http connections
+----------------------------------------------------------
+
+A common use case for modules is to implement the API of an external web service (e.g. https://koodous.com/).
+The (great!) requests library (https://github.com/requests/requests/) provides an easy interface for making
+outbound http connections.
+Viper provides a global configuration section ``[http_client]`` where certain requests options can be set
+for Proxies, TLS Verfication, CA_BUNDLE and TLS Client Certificates.
+Please check the current ``viper.conf.sample``  for more details.
+
+When implementing a custom module settings from the global ``[http_client]]`` can be overridden by specifying
+them again in the configuration section of the custom module and then calling the ``Config.parse_http_client``
+method for the custom module configuration section. Example:
+
+    .. code-block:: ini
+        :linenos:
+
+        # viper.conf
+
+        [http_client]
+        https_proxy = http://prx1.example.internal:3128
+        tls_verify = True
+
+        [mymodule]
+        base_url = https://myapi.example.internal
+        https_proxy = False
+        tls_verify = False
+
+
+    .. code-block:: python
+        :linenos:
+
+        import requests
+        from viper.common.abstracts import Module
+        from viper.core.config import __config__
+
+        cfg = __config__
+        cfg.parse_http_client(cfg.mymodule)
+
+        class MyModule(Module):
+            cmd = 'mycmd'
+            description = 'This module does this and that'
+
+            def run(self):
+                url = cfg.mymodule.base_url
+                r = requests.get(url=url, headers=headers, proxies=cfg.mymodule.proxies, verify=cfg.mymodule.verify, cert=cfg.mymodule.cert)
+
 
 Accessing the session
 ---------------------

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.
+
+import os
+import re
+import sys
+import pytest
+
+from viper.core.config import Config
+
+
+class TestConfig:
+    def test_init(self):
+        instance = Config()
+        assert isinstance(instance, Config)
+        assert re.search("viper.conf", instance.config_file)
+
+    def test_sample(self):
+        instance = Config("viper.conf.sample")
+        assert isinstance(instance, Config)
+        assert instance.modules.store_output is True
+
+    def test_sample_parse_global(self):
+        instance = Config("viper.conf.sample")
+        assert isinstance(instance, Config)
+
+        instance.parse_http_client()
+        assert instance.http_client.proxies is None
+        assert instance.http_client.verify is True
+        assert instance.http_client.cert is None
+
+    def test_sample_parse_global_section(self):
+        instance = Config("viper.conf.sample")
+        assert isinstance(instance, Config)
+
+        instance.parse_http_client(instance.cuckoo)
+
+        assert instance.http_client.proxies is None
+        assert instance.http_client.verify is True
+        assert instance.http_client.cert is None
+
+        assert instance.cuckoo.proxies is None
+        assert instance.cuckoo.verify is True
+        assert instance.cuckoo.cert is None
+
+    def test_custom_parse_global(self):
+        instance = Config("viper.conf.sample")
+        assert isinstance(instance, Config)
+
+        instance.http_client.https_proxy = "http://prx1.example.com:3128"
+        instance.parse_http_client()
+
+        assert instance.http_client.proxies is None
+        assert instance.http_client.verify is True
+        assert instance.http_client.cert is None
+
+        # TODO (frennkie) Write some more parser logic validations here

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2,10 +2,7 @@
 # This file is part of Viper - https://github.com/viper-framework/viper
 # See the file 'LICENSE' for copying permission.
 
-import os
 import re
-import sys
-import pytest
 
 from viper.core.config import Config
 
@@ -51,7 +48,7 @@ class TestConfig:
         instance.http_client.https_proxy = "http://prx1.example.com:3128"
         instance.parse_http_client()
 
-        assert instance.http_client.proxies is None
+        assert instance.http_client.proxies == {'http': 'http://prx1.example.com:3128', 'https': 'http://prx1.example.com:3128', 'no': None}
         assert instance.http_client.verify is True
         assert instance.http_client.cert is None
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -18,9 +18,18 @@ class TestConfig:
         assert isinstance(instance, Config)
         assert instance.modules.store_output is True
 
+    def test_missing_section_http_client(self):
+        instance = Config("viper.conf.sample")
+        assert hasattr(instance, "http_client")
+
+        delattr(instance, "http_client")
+        assert not hasattr(instance, "http_client")
+
+        instance.parse_http_client()
+        assert hasattr(instance, "http_client")
+
     def test_sample_parse_global(self):
         instance = Config("viper.conf.sample")
-        assert isinstance(instance, Config)
 
         instance.parse_http_client()
         assert instance.http_client.proxies is None
@@ -29,7 +38,6 @@ class TestConfig:
 
     def test_sample_parse_global_section(self):
         instance = Config("viper.conf.sample")
-        assert isinstance(instance, Config)
 
         instance.parse_http_client(instance.cuckoo)
 
@@ -43,13 +51,92 @@ class TestConfig:
 
     def test_custom_parse_global(self):
         instance = Config("viper.conf.sample")
-        assert isinstance(instance, Config)
+
+        # http_proxy, no_proxy
+        instance.http_client.https_proxy = None
+        instance.parse_http_client()
+        assert instance.http_client.proxies is None
+
+        instance.http_client.https_proxy = False
+        instance.parse_http_client()
+        assert instance.http_client.proxies == {'http': '', 'https': '', 'no': None}
 
         instance.http_client.https_proxy = "http://prx1.example.com:3128"
         instance.parse_http_client()
-
         assert instance.http_client.proxies == {'http': 'http://prx1.example.com:3128', 'https': 'http://prx1.example.com:3128', 'no': None}
+
+        # tls_verify
+        instance.http_client.tls_verify = None
+        instance.parse_http_client()
         assert instance.http_client.verify is True
+
+        instance.http_client.tls_verify = True
+        instance.parse_http_client()
+        assert instance.http_client.verify is True
+
+        instance.http_client.tls_verify = False
+        instance.parse_http_client()
+        assert instance.http_client.verify is False
+
+        # tls_ca_bundle
+        instance.http_client.tls_verify = True
+        instance.http_client.tls_ca_bundle = "/etc/ssl/certs/ca_bundle.crt"
+        instance.parse_http_client()
+        assert instance.http_client.verify == "/etc/ssl/certs/ca_bundle.crt"
+
+        # tls_client_cert
+        instance.http_client.tls_client_cert = None
+        instance.parse_http_client()
         assert instance.http_client.cert is None
 
+        instance.http_client.tls_client_cert = "client.pem"
+        instance.parse_http_client()
+        assert instance.http_client.cert == "client.pem"
+
         # TODO (frennkie) Write some more parser logic validations here
+    def test_custom_parse_global_section(self):
+        instance = Config("viper.conf.sample")
+
+        # http_proxy, no_proxy
+        instance.http_client.https_proxy = None
+        instance.koodous.https_proxy = None
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.proxies is None
+
+        instance.http_client.https_proxy = "http://prx1.example.com:3128"
+        instance.koodous.https_proxy = None
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.proxies == {'http': 'http://prx1.example.com:3128', 'https': 'http://prx1.example.com:3128', 'no': None}
+
+        instance.http_client.https_proxy = "http://prx1.example.com:3128"
+        instance.koodous.https_proxy = False
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.proxies == {'http': '', 'https': '', 'no': None}
+
+        instance.http_client.https_proxy = "http://prx1.example.com:3128"
+        instance.koodous.https_proxy = "http://prx2.example.com:8080"
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.proxies == {'http': 'http://prx2.example.com:8080', 'https': 'http://prx2.example.com:8080', 'no': None}
+
+        # tls_verify
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.verify is True
+
+        instance.koodous.tls_verify = False
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.verify is False
+
+        instance.koodous.tls_verify = True
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.verify is True
+
+        # tls_ca_bundle
+        instance.koodous.tls_verify = True
+        instance.koodous.tls_ca_bundle = "/etc/ssl/certs/ca_bundle2.crt"
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.verify == "/etc/ssl/certs/ca_bundle2.crt"
+
+        # tls_client_cert
+        instance.koodous.tls_client_cert = "client_koodous.pem"
+        instance.parse_http_client(section=instance.koodous)
+        assert instance.koodous.cert == "client_koodous.pem"

--- a/viper.conf.sample
+++ b/viper.conf.sample
@@ -41,6 +41,29 @@ host = 0.0.0.0
 port = 9090
 
 
+[http_client]
+# http client settings for outgoing requests (e.g. download, VT)
+# will be applied to requests and can be overriden per module
+
+# Proxy specific settings:
+# * https_proxy = e.g. http://user:pass@prx.example.com:3128 (will also set http_proxy)
+# * no_proxy = host1.example.com,internal.domain
+# If https_proxy and no_proxy are not set then settings from the environment will be used.
+# If no proxy should be used then use https_proxy = False (overrides environment)
+#https_proxy =
+#no_proxy =
+
+# tls_verify (default: True): Whether TLS certificates should be validated or not
+#tls_verify = True|False
+
+# tls_ca_bundle: Path to a (custom) ca/ca_bundle file for TLS certificate validation
+#tls_ca_bundle = /root/my_ca_bundle.crt
+
+# tls_client_cert: Path to a TLS client certificate (cert and key) which should be used
+# for authentication
+#tls_client_cert = /root/my_client_cert.pem
+
+
 [autorun]
 enabled = True
 
@@ -86,8 +109,8 @@ misp_taxonomies_directory = ./misp-taxonomies
 # Set the following to select default distribution and sharing group (if in use)
 # Distribution ranges from 0-4, with sharing group only set when distribution is 4.
 # Leave empty to use PyMISP default
-misp_distribution = 
-misp_sharinggroup = 
+misp_distribution =
+misp_sharinggroup =
 
 [pssl]
 pssl_url =

--- a/viper/common/autorun.py
+++ b/viper/common/autorun.py
@@ -8,10 +8,10 @@ from viper.common.out import print_output
 from viper.core.plugins import __modules__
 from viper.core.session import __sessions__
 from viper.core.database import Database
-from viper.core.config import Config
+from viper.core.config import __config__
 from viper.core.storage import get_sample_path
 
-cfg = Config()
+cfg = __config__
 
 
 def parse_commands(data):

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -182,6 +182,7 @@ class Config:
             log.warning("unable to fetch section: {}\n{}".format(section, e))
             print(e)
 
+
 __config__ = Config()
 
 console_output = {}

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -60,7 +60,7 @@ class Config:
                     shutil.copy(cwd_viper, self.config_file)
 
         # Parse the config file.
-        config = ConfigParser()
+        config = self._config = ConfigParser()
         config.read(self.config_file)
 
         # Parse the config file and attribute for the current instantiated
@@ -102,8 +102,8 @@ class Config:
                             "https": self.http_client.https_proxy,
                             "no": self.http_client.no_proxy}
             else:
-                log.debug("Global: Proxy disabled (overriden)")
-                _proxies = {"http": "", "https": "", "no": ""}
+                log.debug("Global: Proxy disabled (overridden)")
+                _proxies = {"http": "", "https": "", "no": None}
 
         if self.http_client.tls_verify is None:
             log.debug("Global: TLS verify not configured")
@@ -143,8 +143,8 @@ class Config:
                                 "https": section.https_proxy,
                                 "no": section.no_proxy}
                 else:
-                    log.debug("Section: Proxy disabled (overriden)")
-                    _proxies = {"http": "", "https": "", "no": ""}
+                    log.debug("Section: Proxy disabled (overridden)")
+                    _proxies = {"http": "", "https": "", "no": None}
 
             if section.tls_verify is None:
                 log.debug("Section: TLS verify not configured")
@@ -182,6 +182,7 @@ class Config:
             log.warning("unable to fetch section: {}\n{}".format(section, e))
             print(e)
 
+__config__ = Config()
 
 console_output = {}
 console_output['filename'] = False

--- a/viper/core/config.py
+++ b/viper/core/config.py
@@ -4,6 +4,7 @@
 
 import os
 from os.path import expanduser
+import logging
 import shutil
 try:
     from configparser import ConfigParser
@@ -12,6 +13,8 @@ except ImportError:
 
 from viper.common.objects import Dictionary
 from viper.common.constants import VIPER_ROOT
+
+log = logging.getLogger('viper')
 
 
 class Config:
@@ -78,6 +81,96 @@ class Config:
 
                 setattr(getattr(self, section), name, value)
 
+    def parse_http_client(self, section=None):
+        _proxies = None
+        _verify = True
+        _cert = None
+
+        # when no http_client section is available provide defaults
+        if self.get("http_client") is None:
+            log.debug("No http_client section in config")
+            setattr(self, "http_client", Dictionary())
+
+        # check global config
+        if self.http_client.https_proxy is None and self.http_client.no_proxy is None:
+            log.debug("Global: Proxy not configured (using ENV or none)")
+        else:
+            if self.http_client.https_proxy:
+                log.debug("Global: Proxy enabled: {} (no: {})".format(self.http_client.https_proxy,
+                                                                      self.http_client.no_proxy))
+                _proxies = {"http": self.http_client.https_proxy,
+                            "https": self.http_client.https_proxy,
+                            "no": self.http_client.no_proxy}
+            else:
+                log.debug("Global: Proxy disabled (overriden)")
+                _proxies = {"http": "", "https": "", "no": ""}
+
+        if self.http_client.tls_verify is None:
+            log.debug("Global: TLS verify not configured")
+        else:
+            if not self.http_client.tls_verify:
+                log.debug("Global: TLS verify disabled")
+                _verify = False
+            else:
+                log.debug("Global: TLS verify enabled")
+
+        if _verify and self.http_client.tls_ca_bundle is not None:
+            if self.http_client.tls_ca_bundle:
+                log.debug("Global: Verify (CA_BUNDLE) set to: {}".format(self.http_client.tls_ca_bundle))
+                _verify = self.http_client.tls_ca_bundle
+
+        if self.http_client.tls_client_cert:
+            log.debug("Global: Client certificate enabled: {}".format(self.http_client.tls_client_cert))
+            _cert = self.http_client.tls_client_cert
+        else:
+            log.debug("Global: Client certificate not configured")
+
+        self.http_client.proxies = _proxies
+        self.http_client.verify = _verify
+        self.http_client.cert = _cert
+
+        if section:
+            # check for module section and override global config if needed
+            if section.https_proxy is None and section.no_proxy is None:
+                if _proxies is None:
+                    log.debug("Section: Proxy not configured (using ENV or none)")
+                else:
+                    log.debug("Section: Proxy not configured (using Global: {})".format(_proxies))
+            else:
+                if section.https_proxy:
+                    log.debug("Section: Proxy enabled: {} (no: {})".format(section.https_proxy, section.no_proxy))
+                    _proxies = {"http": section.https_proxy,
+                                "https": section.https_proxy,
+                                "no": section.no_proxy}
+                else:
+                    log.debug("Section: Proxy disabled (overriden)")
+                    _proxies = {"http": "", "https": "", "no": ""}
+
+            if section.tls_verify is None:
+                log.debug("Section: TLS verify not configured")
+            else:
+                if not section.tls_verify:
+                    log.debug("Section: TLS verify disabled")
+                    _verify = False
+                else:
+                    log.debug("Section: TLS verify enabled")
+                    _verify = True
+
+            if _verify and section.tls_ca_bundle is not None:
+                if section.tls_ca_bundle:
+                    log.debug("Section: Verify (CA_BUNDLE) set to: {}".format(section.tls_ca_bundle))
+                    _verify = section.tls_ca_bundle
+
+            if section.tls_client_cert:
+                log.debug("Section: Client certificate enabled: {}".format(section.tls_client_cert))
+                _cert = section.tls_client_cert
+            else:
+                log.debug("Section: Client certificate not configured")
+
+            section.proxies = _proxies
+            section.verify = _verify
+            section.cert = _cert
+
     def get(self, section):
         """Get option.
         @param section: section to fetch.
@@ -86,6 +179,7 @@ class Config:
         try:
             return getattr(self, section)
         except AttributeError as e:
+            log.warning("unable to fetch section: {}\n{}".format(section, e))
             print(e)
 
 

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -21,12 +21,12 @@ from viper.common.exceptions import Python2UnsupportedUnicode
 from viper.common.objects import File
 from viper.core.storage import get_sample_path, store_sample
 from viper.core.project import __project__
-from viper.core.config import Config
+from viper.core.config import __config__
 
 
 log = logging.getLogger('viper')
 
-cfg = Config()
+cfg = __config__
 
 Base = declarative_base()
 

--- a/viper/core/project.py
+++ b/viper/core/project.py
@@ -6,12 +6,12 @@ import os
 from os.path import expanduser
 import logging
 
-from viper.core.config import Config
 from viper.core.logger import init_logger
+from viper.core.config import __config__
 
 log = logging.getLogger('viper')
 
-cfg = Config()
+cfg = __config__
 
 
 class Project(object):

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -33,11 +33,11 @@ from viper.core.project import __project__
 from viper.core.plugins import __modules__
 from viper.core.database import Database
 from viper.core.storage import store_sample, get_sample_path
-from viper.core.config import Config, console_output
+from viper.core.config import __config__, console_output
 from viper.common.autorun import autorun_module
 from viper.core.archiver import Compressor
 
-cfg = Config()
+cfg = __config__
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
 try:

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -20,11 +20,11 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__, get_project_list
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
-from viper.core.config import Config, console_output
+from viper.core.config import __config__, console_output
 
 log = logging.getLogger('viper')
 
-cfg = Config()
+cfg = __config__
 cfg.parse_http_client()
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -25,6 +25,7 @@ from viper.core.config import Config, console_output
 log = logging.getLogger('viper')
 
 cfg = Config()
+cfg.parse_http_client()
 
 # For python2 & 3 compat, a bit dirty, but it seems to be the least bad one
 try:

--- a/viper/modules/image.py
+++ b/viper/modules/image.py
@@ -3,6 +3,7 @@
 # See the file 'LICENSE' for copying permission.
 
 from io import BytesIO
+import logging
 
 try:
     import requests
@@ -13,6 +14,11 @@ except ImportError:
 from viper.common.out import bold
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
+from viper.core.config import __config__
+
+log = logging.getLogger('viper')
+
+cfg = __config__
 
 
 class Image(Module):
@@ -32,7 +38,8 @@ class Image(Module):
         payload = dict(private='true', json='true')
         files = dict(image=BytesIO(__sessions__.current.file.data))
 
-        response = requests.post('http://www.imageforensic.org/api/submit/', data=payload, files=files)
+        response = requests.post('http://www.imageforensic.org/api/submit/', data=payload, files=files,
+                                 proxies=cfg.http_client.proxies, verify=cfg.http_client.verify, cert=cfg.http_client.cert)
         results = response.json()
 
         if results['success']:

--- a/viper/modules/koodous.py
+++ b/viper/modules/koodous.py
@@ -17,11 +17,11 @@ import tempfile
 
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
-from viper.core.config import Config
+from viper.core.config import __config__
 
 log = logging.getLogger('viper')
 
-cfg = Config()
+cfg = __config__
 cfg.parse_http_client(cfg.koodous)
 # Call: requests.get(url, proxies=cfg.koodous.proxies, verify=cfg.koodous.verify, cert=cfg.koodous.cert)
 

--- a/viper/modules/koodous.py
+++ b/viper/modules/koodous.py
@@ -11,6 +11,7 @@ except ImportError:
     HAVE_REQUESTS = False
 
 from io import BytesIO
+import logging
 import hashlib
 import tempfile
 
@@ -18,7 +19,11 @@ from viper.common.abstracts import Module
 from viper.core.session import __sessions__
 from viper.core.config import Config
 
+log = logging.getLogger('viper')
+
 cfg = Config()
+cfg.parse_http_client(cfg.koodous)
+# Call: requests.get(url, proxies=cfg.koodous.proxies, verify=cfg.koodous.verify, cert=cfg.koodous.cert)
 
 
 class Koodous(Module):
@@ -74,10 +79,12 @@ class Koodous(Module):
 
         headers = {'Authorization': 'Token %s' % cfg.koodous.token}
 
-        response = requests.get(url=url, headers=headers)
+        response = requests.get(url=url, headers=headers, proxies=cfg.koodous.proxies,
+                                verify=cfg.koodous.verify, cert=cfg.koodous.cert)
         if response.status_code == 200:
             down_url = response.json().get('download_url', None)
-            response = requests.get(url=down_url)
+            response = requests.get(url=down_url, proxies=cfg.koodous.proxies,
+                                    verify=cfg.koodous.verify, cert=cfg.koodous.cert)
 
             sha256_downloaded = hashlib.sha256(response.content).hexdigest()
             if sha256_downloaded != sha256:
@@ -98,27 +105,37 @@ class Koodous(Module):
             return
         sha256 = hashlib.sha256(content_file).hexdigest()
 
-        url = '%s/%s/get_upload_url' % (cfg.koodous.koodous_url, sha256)
-        headers = {"Authorization": "Token %s" % cfg.koodous.koodous_token}
+        url = '%s/%s/get_upload_url' % (cfg.koodous.base_url, sha256)
+        headers = {"Authorization": "Token %s" % cfg.koodous.token}
 
-        response = requests.get(url=url, headers=headers)
-        if response.status_code == 200:
-            upload_url = response.json().get('upload_url', None)
-            files = {'file': BytesIO(__sessions__.current.file.data)}
-            response = requests.post(url=upload_url, files=files)
-            if response == 200:
-                self.log("File uploaded correctly.")
-                return
-        elif response.status_code == 409:
-            self.log('info', 'This file already exists in Koodous.')
-        else:
-            self.log('error', 'Unknown error, sorry!')
+        try:
+            response = requests.get(url=url, headers=headers, proxies=cfg.koodous.proxies,
+                                    verify=cfg.koodous.verify, cert=cfg.koodous.cert)
+
+            if response.status_code == 200:
+                upload_url = response.json().get('upload_url', None)
+                files = {'file': BytesIO(__sessions__.current.file.data)}
+                response = requests.post(url=upload_url, files=files, proxies=cfg.koodous.proxies,
+                                         verify=cfg.koodous.verify, cert=cfg.koodous.cert)
+
+                if response == 200:
+                    self.log("File uploaded correctly.")
+                    return
+            elif response.status_code == 409:
+                self.log('info', 'This file already exists in Koodous.')
+            else:
+                self.log('error', 'Unknown error, sorry!')
+                log.error("Unknown error, sorry! Response: \n{}".format(response.status_code))
+
+        except Exception as err:
+            self.log('error', 'Network problem, please try again.')
+            log.error("Network problem, please try again: \n{}".format(err))
 
     def _comment(self, comment):
         """
             Function to comment an APK in Koodous
         """
-        headers = {"Authorization": "Token %s" % cfg.koodous.koodous_token}
+        headers = {"Authorization": "Token %s" % cfg.koodous.token}
 
         try:
             content_file = __sessions__.current.file.data
@@ -127,21 +144,24 @@ class Koodous(Module):
             self.log('error', 'You have no file loaded')
 
         try:
-            url = '%s/%s/comments' % (cfg.koodous.koodous_url, sha256)
+            url = '%s/%s/comments' % (cfg.koodous.base_url, sha256)
             data = {'text': comment}
-            response = requests.post(url=url, headers=headers, data=data)
+            response = requests.post(url=url, headers=headers, data=data,
+                                     proxies=cfg.koodous.proxies, verify=cfg.koodous.verify, cert=cfg.koodous.cert)
+
             if response.status_code == 201:
                 self.log('info', 'Comment made successfully.')
             else:
                 self.log('error', 'Some problem saving the comment, please try again.')
-        except:
+        except Exception as err:
             self.log('error', 'Network problem, please try again.')
+            log.error("Network problem, please try again: \n{}".format(err))
 
     def _show_comments(self):
         """
             Function to view comments of a sample in Koodous
         """
-        headers = {"Authorization": "Token %s" % cfg.koodous.koodous_token}
+        headers = {"Authorization": "Token %s" % cfg.koodous.token}
 
         try:
             content_file = __sessions__.current.file.data
@@ -150,12 +170,15 @@ class Koodous(Module):
             self.log('error', 'You have no file loaded')
             return
         try:
-            url = '%s/%s/comments' % (cfg.koodous.koodous_url, sha256)
-            response = requests.get(url=url, headers=headers)
+            url = '%s/%s/comments' % (cfg.koodous.base_url, sha256)
+            response = requests.get(url=url, headers=headers, proxies=cfg.koodous.proxies,
+                                    verify=cfg.koodous.verify, cert=cfg.koodous.cert)
+
             if response.json().get('count') == 0:
                 self.log('info', 'This sample has no comments.')
                 return
             for result in response.json().get('results'):
                 self.log('info', "[{}]: {}".format(result['author']['username'], result['text']))
-        except:
+        except Exception as err:
             self.log('error', 'Network problem, please try again.')
+            log.error("Network problem, please try again: \n{}".format(err))

--- a/viper/modules/lastline.py
+++ b/viper/modules/lastline.py
@@ -3,6 +3,7 @@
 # See the file 'LICENSE' for copying permission.
 
 from io import BytesIO
+import logging
 import json
 
 try:
@@ -13,9 +14,12 @@ except ImportError:
 
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+log = logging.getLogger('viper')
+
+cfg = __config__
+cfg.parse_http_client(cfg.lastline)
 
 
 class LastLine(Module):
@@ -47,7 +51,8 @@ class LastLine(Module):
                 file = {'file': BytesIO(__sessions__.current.file.data)}
                 data = {'key': cfg.lastline.key, 'api_token': cfg.lastline.token,
                         'push_to_portal_account': cfg.lastline.portal_account}
-                response = requests.post(cfg.lastline.base_url, data=data, files=file)
+                response = requests.post(cfg.lastline.base_url, data=data, files=file,
+                                         proxies=cfg.lastline.proxies, verify=cfg.lastline.verify, cert=cfg.lastline.cert)
                 response = response.json()
 
                 if response['success'] == 0:
@@ -65,7 +70,8 @@ class LastLine(Module):
 
             data = {'key': cfg.lastline.key, 'api_token': cfg.lastline.token, 'md5': __sessions__.current.file.md5,
                     'push_to_portal_account': cfg.lastline.portal_account}
-            response = requests.post(cfg.lastline.base_url, data=data)
+            response = requests.post(cfg.lastline.base_url, data=data,
+                                     proxies=cfg.lastline.proxies, verify=cfg.lastline.verify, cert=cfg.lastline.cert)
             response = response.json()
             if response['success'] == 0:
                 self.log('error', response['error'])

--- a/viper/modules/misp.py
+++ b/viper/modules/misp.py
@@ -27,9 +27,9 @@ from viper.core.project import __project__
 from viper.core.storage import get_sample_path
 from viper.common.objects import MispEvent
 from viper.common.constants import VIPER_ROOT
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+cfg = __config__
 
 
 class MISP(Module):

--- a/viper/modules/misp_methods/check_hashes.py
+++ b/viper/modules/misp_methods/check_hashes.py
@@ -20,9 +20,9 @@ except:
 
 from viper.core.session import __sessions__
 from viper.common.objects import MispEvent
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+cfg = __config__
 
 
 # ####### Helpers for check_hashes ########

--- a/viper/modules/pdns.py
+++ b/viper/modules/pdns.py
@@ -6,9 +6,9 @@ from pypdns import PyPDNS
 
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+cfg = __config__
 
 
 class Pdns(Module):

--- a/viper/modules/pssl.py
+++ b/viper/modules/pssl.py
@@ -6,9 +6,9 @@ from pypssl import PyPSSL
 
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+cfg = __config__
 
 
 class Pssl(Module):

--- a/viper/modules/reports.py
+++ b/viper/modules/reports.py
@@ -4,6 +4,7 @@
 
 import re
 import json
+import logging
 import getpass
 
 try:
@@ -23,9 +24,12 @@ except ImportError:
 from viper.common.utils import string_clean
 from viper.common.abstracts import Module
 from viper.core.session import __sessions__
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+log = logging.getLogger('viper')
+
+cfg = __config__
+cfg.parse_http_client(cfg.reports)
 
 
 class Reports(Module):
@@ -77,18 +81,21 @@ class Reports(Module):
             sess = requests.Session()
             sess.auth = (username, password)
 
-            sess.get(cfg.reports.malwr_login, verify=False)
+            sess.get(cfg.reports.malwr_login, proxies=cfg.reports.proxies, verify=cfg.reports.verify, cert=cfg.reports.cert)
             csrf = sess.cookies['csrftoken']
 
             sess.post(
                 cfg.reports.malwr_login,
                 {'username': username, 'password': password, 'csrfmiddlewaretoken': csrf},
                 headers=dict(Referer=cfg.reports.malwr_login),
-                verify=False,
-                timeout=60
+                timeout=60,
+                proxies=cfg.reports.proxies,
+                verify=cfg.reports.verify,
+                cert=cfg.reports.cert
             )
-        except:
+        except Exception as err:
             self.log('info', "Error while connecting to malwr")
+            log.error("Error while connecting to malwr: \n{}".format(err))
             return
         payload = {'search': __sessions__.current.file.sha256, 'csrfmiddlewaretoken': csrf}
         headers = {"Referer": cfg.reports.malwr_search}
@@ -97,7 +104,9 @@ class Reports(Module):
             payload,
             headers=headers,
             timeout=60,
-            verify=False
+            proxies=cfg.reports.proxies,
+            verify=cfg.reports.verify,
+            cert=cfg.reports.cert
         )
 
         reports = self.malwr_parse(p.text)
@@ -110,7 +119,7 @@ class Reports(Module):
     def threat(self):
         # need the URL and the date
         url = 'http://www.threatexpert.com/report.aspx?md5={0}'.format(__sessions__.current.file.md5)
-        page = requests.get(url)
+        page = requests.get(url, proxies=cfg.reports.proxies, verify=cfg.reports.verify, cert=cfg.reports.cert)
         reports = []
         soup = BeautifulSoup(page.text)
         if soup.title.text.startswith('ThreatExpert Report'):
@@ -124,7 +133,7 @@ class Reports(Module):
 
     def joe(self):
         url = 'http://www.joesecurity.org/reports/report-{0}.html'.format(__sessions__.current.file.md5)
-        page = requests.get(url)
+        page = requests.get(url, proxies=cfg.reports.proxies, verify=cfg.reports.verify, cert=cfg.reports.cert)
         if '<h2>404 - File Not Found</h2>' in page.text or 'Apparently the requested URL could not be found' in page.text:
             self.log('info', "No reports for opened file")
         elif '403 Forbidden' in page.text:
@@ -134,7 +143,7 @@ class Reports(Module):
 
     def meta(self):
         url = 'https://www.metascan-online.com/en/scanresult/file/{0}'.format(__sessions__.current.file.md5)
-        page = requests.get(url)
+        page = requests.get(url, proxies=cfg.reports.proxies, verify=cfg.reports.verify, cert=cfg.reports.cert)
         reports = []
         if '<title>Error</title>' in page.text:
             self.log('info', "No reports for opened file")

--- a/viper/modules/scraper.py
+++ b/viper/modules/scraper.py
@@ -10,7 +10,7 @@ from glob import glob
 from shutil import copy2
 
 from viper.common.abstracts import Module
-from viper.core.config import Config
+from viper.core.config import __config__
 from viper.core.project import __project__
 import logging
 
@@ -34,7 +34,7 @@ try:
 except:
     HAVE_ETE = False
 
-cfg = Config()
+cfg = __config__
 
 
 class Scraper(Module):

--- a/viper/modules/virustotal.py
+++ b/viper/modules/virustotal.py
@@ -5,6 +5,7 @@
 import os
 import glob
 import shutil
+import logging
 import json
 
 try:
@@ -21,9 +22,12 @@ from viper.common.abstracts import Module
 from viper.common.objects import MispEvent
 from viper.core.session import __sessions__
 from viper.core.project import __project__
-from viper.core.config import Config
+from viper.core.config import __config__
 
-cfg = Config()
+log = logging.getLogger('viper')
+
+cfg = __config__
+cfg.parse_http_client(cfg.virustotal)
 
 
 class VirusTotal(Module):
@@ -38,12 +42,12 @@ class VirusTotal(Module):
             return
         self.cur_path = __project__.get_path()
         if cfg.virustotal.virustotal_has_private_key:
-            self.vt = vt_priv(cfg.virustotal.virustotal_key)
+            self.vt = vt_priv(cfg.virustotal.virustotal_key, proxies=cfg.virustotal.proxies)
         else:
-            self.vt = vt(cfg.virustotal.virustotal_key)
+            self.vt = vt(cfg.virustotal.virustotal_key, proxies=cfg.virustotal.proxies)
 
         if cfg.virustotal.virustotal_has_intel_key:
-            self.vt_intel = vt_intel(cfg.virustotal.virustotal_key)
+            self.vt_intel = vt_intel(cfg.virustotal.virustotal_key, proxies=cfg.virustotal.proxies)
 
         self.parser.add_argument('--search', help='Search a hash.')
         self.parser.add_argument('-c', '--comment', nargs='+', help='Comment to add to the file')

--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -16,7 +16,7 @@ from viper.common.abstracts import Module
 from viper.core.database import Database
 from viper.core.session import __sessions__
 from viper.core.storage import get_sample_path
-from viper.core.config import Config
+from viper.core.config import __config__
 
 try:
     import yara
@@ -24,7 +24,7 @@ try:
 except ImportError:
     HAVE_YARA = False
 
-cfg = Config()
+cfg = __config__
 
 
 def string_printable(line):


### PR DESCRIPTION
This PR adds the possiblity to set http_client setting in config file that will be passed on to requests.
The settings are made globally in the new section `http_client` and can be overridden for specific modules (e.g. koodous). Fixes #595.

This also fixes a few issues in koodous.py (wrong name for url and token setting).

ToDos
* [x] add more logic tests
* [x] dev documentation?!

Other modules that should be checked and updated
* [x] cuckoo
* [x] image
* [x] koodous
* [x] lastline
* [x] misp_methods/check_hashes
* [x] misp
* [x] reports