### PR TITLE
[WIP] Enable pip (global) installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,12 @@
 include LICENSE
 include README.rst
+include README.md
 include CHANGELOG
 include requirements.txt
 include requirements-*.txt
-recursive-include data *.*
+include viper.conf.sample
+recursive-include data/peid/ *.*
+recursive-include data/yara/ *.*
+recursive-include data/web/ *.*
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -32,21 +32,21 @@ simplejson==3.10.0
 virustotal-api==1.1.5
 
 git+https://github.com/viper-framework/pefile.git#egg=pefile
-git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool
+git+https://github.com/smarnach/pyexiftool.git#egg=PyExifTool
 
 
 # office module
 olefile==0.44
-git+https://github.com/decalage2/oletools.git
+git+https://github.com/decalage2/oletools.git#egg=oletools
 ## Flash lookup
-git+https://github.com/viper-framework/xxxswf.git
+git+https://github.com/viper-framework/xxxswf.git#egg=xxxswf
 
 # apk module
 ipython < 6; python_version == '2.7'
-git+https://github.com/androguard/androguard.git
+androguard>=3.0
 
 # pe module (verify sigs)
-git+https://github.com/sebdraven/verify-sigs.git
+git+https://github.com/sebdraven/verify-sigs.git#egg=verify-sigs
 
 # archiving
 rarfile==3.0
@@ -54,9 +54,9 @@ rarfile==3.0
 yara-python==3.5.0
 
 # Scraper
-git+https://github.com/viper-framework/ScrapySplashWrapper.git
+git+https://github.com/viper-framework/ScrapySplashWrapper.git#egg=ScrapySplashWrapper
 
 # MISP
-git+https://github.com/MISP/PyTaxonomies.git
-git+https://github.com/MISP/PyMISPGalaxies.git
+git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
+git+https://github.com/MISP/PyMISPGalaxies.git#egg=pymispgalaxies
 pymisp==2.4.77

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import setup
 from viper.common.version import __version__
 from viper.common.constants import VIPER_RULES_DIST_DIR
 
+
 def get_packages(package):
     """
     Return root package and all sub-packages.
@@ -52,7 +53,6 @@ for req_file in requirement_files:
             links.append(str(item.link))
         if item.req:
             requires.append(str(item.req))
-
 
 description = "Binary Analysis & Management Framework"
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import glob
 from setuptools import setup
 
 from viper.common.version import __version__
-from viper.common.constants import VIPER_RULES_DIST_DIR
+from viper.common.constants import DIST_DIR_YARA_RULES, DIST_DIR_PEID
 
 
 def get_packages(package):
@@ -73,7 +73,8 @@ setup(
     install_requires=requires,
     dependency_links=links,
     data_files=[('/', ['viper.conf.sample']),
-                ('/' + VIPER_RULES_DIST_DIR, glob.glob("data/yara/*"))],
+                ('/' + DIST_DIR_PEID, glob.glob("data/peid/*")),
+                ('/' + DIST_DIR_YARA_RULES, glob.glob("data/yara/*"))],
     zip_safe=False,
 
     tests_require=['pytest'],

--- a/viper-web
+++ b/viper-web
@@ -35,6 +35,7 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__
 from viper.common.objects import File
 from viper.core.storage import store_sample, get_sample_path
+from viper.core.storage import check_and_deploy_yara_rules
 from viper.core.database import Database
 from viper.common import network
 from viper.core.ui.commands import Commands
@@ -66,6 +67,9 @@ for folder in ['/usr/share/viper/web/', os.path.join(VIPER_ROOT, 'data/web')]:
         web_root = folder
         bottle.TEMPLATE_PATH.insert(0, folder)
         break
+
+# make sure Yara rules are available in storage path
+check_and_deploy_yara_rules()
 
 # Module Dicts
 mod_dicts = {}
@@ -121,13 +125,13 @@ def print_output(output):
         if entry['type'] == 'table':
             # set the table
             return_html += '<table class="table table-bordered">'
-            
+
             # Column Titles
             return_html += '<tr>'
             for column in entry['data']['header']:
                 return_html += '<th>{0}</th>'.format(bleach.clean(column))
             return_html += '</tr>'
-            
+
             # Rows
             for row in entry['data']['rows']:
                 return_html += '<tr>'
@@ -636,7 +640,7 @@ def run_module():
 def yara_rules():
 
     # Get list of Rules
-    rule_path = os.path.join(VIPER_ROOT, 'data/yara')
+    rule_path = os.path.join(__project__.base_path, 'yara')
     rule_list = os.listdir(rule_path)
 
     # GET is for listing Rules

--- a/viper-web
+++ b/viper-web
@@ -35,7 +35,7 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__
 from viper.common.objects import File
 from viper.core.storage import store_sample, get_sample_path
-from viper.core.storage import check_and_deploy_yara_rules
+from viper.core.storage import check_and_deploy_peid, check_and_deploy_yara_rules
 from viper.core.database import Database
 from viper.common import network
 from viper.core.ui.commands import Commands
@@ -68,7 +68,8 @@ for folder in ['/usr/share/viper/web/', os.path.join(VIPER_ROOT, 'data/web')]:
         bottle.TEMPLATE_PATH.insert(0, folder)
         break
 
-# make sure Yara rules are available in storage path
+# make sure PEID info and Yara rules are available in storage path
+check_and_deploy_peid()
 check_and_deploy_yara_rules()
 
 # Module Dicts

--- a/viper/common/constants.py
+++ b/viper/common/constants.py
@@ -6,3 +6,5 @@ import os
 
 _current_dir = os.path.abspath(os.path.dirname(__file__))
 VIPER_ROOT = os.path.normpath(os.path.join(_current_dir, "..", ".."))
+
+VIPER_RULES_DIST_DIR = "viper_data_yara"

--- a/viper/common/constants.py
+++ b/viper/common/constants.py
@@ -7,4 +7,5 @@ import os
 _current_dir = os.path.abspath(os.path.dirname(__file__))
 VIPER_ROOT = os.path.normpath(os.path.join(_current_dir, "..", ".."))
 
-VIPER_RULES_DIST_DIR = "viper_data_yara"
+DIST_DIR_YARA_RULES = "viper_data_yara"
+DIST_DIR_PEID = "viper_data_peid"

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -4,10 +4,14 @@
 
 import os
 import shutil
+import logging
 
-from viper.common.out import print_warning, print_error, print_info
+from viper.common.out import print_warning, print_error
 from viper.core.project import __project__
 from viper.common.constants import VIPER_ROOT, DIST_DIR_YARA_RULES, DIST_DIR_PEID
+from viper.core.logger import init_logger
+
+log = logging.getLogger('viper')
 
 
 def store_sample(file_object):
@@ -63,42 +67,51 @@ def check_and_deploy_yara_rules():
     """Yara: check whether rule path exist - if not copy default set of rules to directory"""
     yara_rules_path = os.path.join(__project__.base_path, "yara")
     if os.path.exists(yara_rules_path):
-        print_info("Using Yara rules from directory: {}".format(yara_rules_path))
+        log.info("Using Yara rules from directory: {}".format(yara_rules_path))
     else:
         # Prio 1: rules if Viper was installed with pip
         yara_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_YARA_RULES)
 
-        # Prio 2: rules if Viper was checkout from repo
+        # Prio 2: rules if Viper is cloned from repo
         yara_path_repo = os.path.join(VIPER_ROOT, "data", "yara")
 
         if os.path.exists(yara_path_setup_utils):
             print_warning("Yara rule directory not found - copying default "
                           "rules ({}) to: {}".format(yara_path_setup_utils, yara_rules_path))
+            log.warning("Yara rule directory not found - copying default "
+                        "rules ({}) to: {}".format(yara_path_setup_utils, yara_rules_path))
 
             shutil.copytree(yara_path_setup_utils, yara_rules_path)
         elif os.path.exists(yara_path_repo):
             print_warning("Yara rule directory not found - copying default "
                           "rules ({}) to: {}".format(yara_path_repo, yara_rules_path))
+            log.warning("Yara rule directory not found - copying default "
+                        "rules ({}) to: {}".format(yara_path_repo, yara_rules_path))
             shutil.copytree(yara_path_repo, yara_rules_path)
         else:
             print_error("No default Yara rules found")
+            log.error("No default Yara rules found")
 
 
 def check_and_deploy_peid():
     """PEID: check whether PEID dir exist - if not copy default to directory"""
     peid_path = os.path.join(__project__.base_path, "peid")
     if os.path.exists(peid_path):
-        print_info("Using PEID info from directory: {}".format(peid_path))
+        log.info("Using PEID info from directory: {}".format(peid_path))
     else:
         # Prio 1: peid info if Viper was installed with pip
         peid_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_PEID)
 
-        # Prio 2: peid info if Viper was checkout from repo
+        # Prio 2: peid info if Viper is cloned from repo
         peid_path_repo = os.path.join(VIPER_ROOT, "data", "peid")
 
         if os.path.exists(peid_path_setup_utils):
+            log.warning("PEID info directory not found - copying default "
+                        "rules ({}) to: {}".format(peid_path_setup_utils, peid_path))
             shutil.copytree(peid_path_setup_utils, peid_path)
         elif os.path.exists(peid_path_repo):
+            log.warning("PEID info directory not found - copying default "
+                        "rules ({}) to: {}".format(peid_path_repo, peid_path))
             shutil.copytree(peid_path_repo, peid_path)
         else:
             pass

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -7,8 +7,7 @@ import shutil
 
 from viper.common.out import print_warning, print_error, print_info
 from viper.core.project import __project__
-from viper.common.constants import VIPER_ROOT
-from viper.common.constants import VIPER_RULES_DIST_DIR
+from viper.common.constants import VIPER_ROOT, DIST_DIR_YARA_RULES, DIST_DIR_PEID
 
 
 def store_sample(file_object):
@@ -67,7 +66,7 @@ def check_and_deploy_yara_rules():
         print_info("Using Yara rules from directory: {}".format(yara_rules_path))
     else:
         # Prio 1: rules if Viper was installed with pip
-        yara_path_setup_utils = os.path.join(VIPER_ROOT, VIPER_RULES_DIST_DIR)
+        yara_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_YARA_RULES)
 
         # Prio 2: rules if Viper was checkout from repo
         yara_path_repo = os.path.join(VIPER_ROOT, "data", "yara")
@@ -83,3 +82,23 @@ def check_and_deploy_yara_rules():
             shutil.copytree(yara_path_repo, yara_rules_path)
         else:
             print_error("No default Yara rules found")
+
+
+def check_and_deploy_peid():
+    """PEID: check whether PEID dir exist - if not copy default to directory"""
+    peid_path = os.path.join(__project__.base_path, "peid")
+    if os.path.exists(peid_path):
+        print_info("Using PEID info from directory: {}".format(peid_path))
+    else:
+        # Prio 1: peid info if Viper was installed with pip
+        peid_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_PEID)
+
+        # Prio 2: peid info if Viper was checkout from repo
+        peid_path_repo = os.path.join(VIPER_ROOT, "data", "peid")
+
+        if os.path.exists(peid_path_setup_utils):
+            shutil.copytree(peid_path_setup_utils, peid_path)
+        elif os.path.exists(peid_path_repo):
+            shutil.copytree(peid_path_repo, peid_path)
+        else:
+            pass

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -3,9 +3,12 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+import shutil
 
-from viper.common.out import print_warning, print_error
+from viper.common.out import print_warning, print_error, print_info
 from viper.core.project import __project__
+from viper.common.constants import VIPER_ROOT
+from viper.common.constants import VIPER_RULES_DIST_DIR
 
 
 def store_sample(file_object):
@@ -55,3 +58,28 @@ def get_sample_path(sha256):
         return None
 
     return path
+
+
+def check_and_deploy_yara_rules():
+    """Yara: check whether rule path exist - if not copy default set of rules to directory"""
+    yara_rules_path = os.path.join(__project__.base_path, "yara")
+    if os.path.exists(yara_rules_path):
+        print_info("Using Yara rules from directory: {}".format(yara_rules_path))
+    else:
+        # Prio 1: rules if Viper was installed with pip
+        yara_path_setup_utils = os.path.join(VIPER_ROOT, VIPER_RULES_DIST_DIR)
+
+        # Prio 2: rules if Viper was checkout from repo
+        yara_path_repo = os.path.join(VIPER_ROOT, "data", "yara")
+
+        if os.path.exists(yara_path_setup_utils):
+            print_warning("Yara rule directory not found - copying default "
+                          "rules ({}) to: {}".format(yara_path_setup_utils, yara_rules_path))
+
+            shutil.copytree(yara_path_setup_utils, yara_rules_path)
+        elif os.path.exists(yara_path_repo):
+            print_warning("Yara rule directory not found - copying default "
+                          "rules ({}) to: {}".format(yara_path_repo, yara_rules_path))
+            shutil.copytree(yara_path_repo, yara_rules_path)
+        else:
+            print_error("No default Yara rules found")

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -9,7 +9,6 @@ import logging
 from viper.common.out import print_warning, print_error
 from viper.core.project import __project__
 from viper.common.constants import VIPER_ROOT, DIST_DIR_YARA_RULES, DIST_DIR_PEID
-from viper.core.logger import init_logger
 
 log = logging.getLogger('viper')
 

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -107,11 +107,11 @@ def check_and_deploy_peid():
 
         if os.path.exists(peid_path_setup_utils):
             log.warning("PEID info directory not found - copying default "
-                        "rules ({}) to: {}".format(peid_path_setup_utils, peid_path))
+                        "info ({}) to: {}".format(peid_path_setup_utils, peid_path))
             shutil.copytree(peid_path_setup_utils, peid_path)
         elif os.path.exists(peid_path_repo):
             log.warning("PEID info directory not found - copying default "
-                        "rules ({}) to: {}".format(peid_path_repo, peid_path))
+                        "info ({}) to: {}".format(peid_path_repo, peid_path))
             shutil.copytree(peid_path_repo, peid_path)
         else:
             pass

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -20,6 +20,7 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__, get_project_list
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
+from viper.core.storage import check_and_deploy_yara_rules
 from viper.core.config import __config__, console_output
 
 log = logging.getLogger('viper')
@@ -106,6 +107,9 @@ class Console(object):
     def start(self):
         # log start
         log.info('Starting viper-cli')
+
+        # make sure Yara rules are available in storage path
+        check_and_deploy_yara_rules()
 
         # Logo.
         logo()

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -20,7 +20,7 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__, get_project_list
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
-from viper.core.storage import check_and_deploy_yara_rules
+from viper.core.storage import check_and_deploy_peid, check_and_deploy_yara_rules
 from viper.core.config import __config__, console_output
 
 log = logging.getLogger('viper')
@@ -108,7 +108,8 @@ class Console(object):
         # log start
         log.info('Starting viper-cli')
 
-        # make sure Yara rules are available in storage path
+        # make sure PEID info and Yara rules are available in storage path
+        check_and_deploy_peid()
         check_and_deploy_yara_rules()
 
         # Logo.

--- a/viper/modules/pe.py
+++ b/viper/modules/pe.py
@@ -37,6 +37,7 @@ from viper.common.utils import get_type, get_md5
 from viper.core.database import Database
 from viper.core.storage import get_sample_path
 from viper.core.session import __sessions__
+from viper.core.project import __project__
 
 
 class PE(Module):
@@ -305,7 +306,9 @@ class PE(Module):
 
         def get_signatures():
             userdb_path = None
-            for path_attempt in ['/usr/share/viper/peid/UserDB.TXT', os.path.join(VIPER_ROOT, 'data/peid/UserDB.TXT')]:
+            for path_attempt in ['/usr/share/viper/peid/UserDB.TXT',
+                                 os.path.join(__project__.base_path, 'peid/UserDB.TXT'),
+                                 os.path.join(VIPER_ROOT, 'data/peid/UserDB.TXT')]:
                 if os.path.exists(path_attempt):
                     userdb_path = path_attempt
                     break


### PR DESCRIPTION
Update manifest and setup.py to enable (global) installation with pip.
For this it is also needed to change the path where the used Yara rules
are stored. To avoid any issue with existing installations the rules
will automatically be copied on first start after upgrade (if missing).