### PR TITLE
Pinning version causes an issue due to a change in pyasn1

### DIFF
--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -16,7 +16,7 @@ MarkupSafe==1.0
 mccabe==0.6.1
 openapi-codec==1.3.1
 packaging==16.8
-pyasn1==0.2.3
+pyasn1
 pycodestyle==2.3.1
 pycparser==2.17
 pycrypto==2.6.1


### PR DESCRIPTION
As discussed in viper-framework/ScrapySplashWrapper#1.