### PR TITLE
change the way yara rules and peid files are handled

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
 include LICENSE
-include README.rst
+include README.md
 include CHANGELOG
 include requirements.txt
 include requirements-*.txt
-recursive-include data *.*
+include viper.conf.sample
+recursive-include data/peid/ *.*
+recursive-include data/yara/ *.*
+recursive-include data/web/ *.*
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/viper/common/constants.py
+++ b/viper/common/constants.py
@@ -6,3 +6,6 @@ import os
 
 _current_dir = os.path.abspath(os.path.dirname(__file__))
 VIPER_ROOT = os.path.normpath(os.path.join(_current_dir, "..", ".."))
+
+DIST_DIR_YARA_RULES = "viper_data_yara"
+DIST_DIR_PEID = "viper_data_peid"

--- a/viper/core/storage.py
+++ b/viper/core/storage.py
@@ -3,9 +3,11 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+import shutil
 
-from viper.common.out import print_warning, print_error
+from viper.common.out import print_warning, print_error, print_info
 from viper.core.project import __project__
+from viper.common.constants import VIPER_ROOT, DIST_DIR_YARA_RULES, DIST_DIR_PEID
 
 
 def store_sample(file_object):
@@ -55,3 +57,48 @@ def get_sample_path(sha256):
         return None
 
     return path
+
+
+def check_and_deploy_yara_rules():
+    """Yara: check whether rule path exist - if not copy default set of rules to directory"""
+    yara_rules_path = os.path.join(__project__.base_path, "yara")
+    if os.path.exists(yara_rules_path):
+        print_info("Using Yara rules from directory: {}".format(yara_rules_path))
+    else:
+        # Prio 1: rules if Viper was installed with pip
+        yara_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_YARA_RULES)
+
+        # Prio 2: rules if Viper was checkout from repo
+        yara_path_repo = os.path.join(VIPER_ROOT, "data", "yara")
+
+        if os.path.exists(yara_path_setup_utils):
+            print_warning("Yara rule directory not found - copying default "
+                          "rules ({}) to: {}".format(yara_path_setup_utils, yara_rules_path))
+
+            shutil.copytree(yara_path_setup_utils, yara_rules_path)
+        elif os.path.exists(yara_path_repo):
+            print_warning("Yara rule directory not found - copying default "
+                          "rules ({}) to: {}".format(yara_path_repo, yara_rules_path))
+            shutil.copytree(yara_path_repo, yara_rules_path)
+        else:
+            print_error("No default Yara rules found")
+
+
+def check_and_deploy_peid():
+    """PEID: check whether PEID dir exist - if not copy default to directory"""
+    peid_path = os.path.join(__project__.base_path, "peid")
+    if os.path.exists(peid_path):
+        print_info("Using PEID info from directory: {}".format(peid_path))
+    else:
+        # Prio 1: peid info if Viper was installed with pip
+        peid_path_setup_utils = os.path.join(VIPER_ROOT, DIST_DIR_PEID)
+
+        # Prio 2: peid info if Viper was checkout from repo
+        peid_path_repo = os.path.join(VIPER_ROOT, "data", "peid")
+
+        if os.path.exists(peid_path_setup_utils):
+            shutil.copytree(peid_path_setup_utils, peid_path)
+        elif os.path.exists(peid_path_repo):
+            shutil.copytree(peid_path_repo, peid_path)
+        else:
+            pass

--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -20,6 +20,7 @@ from viper.core.plugins import __modules__
 from viper.core.project import __project__, get_project_list
 from viper.core.ui.commands import Commands
 from viper.core.database import Database
+from viper.core.storage import check_and_deploy_peid, check_and_deploy_yara_rules
 from viper.core.config import __config__, console_output
 
 log = logging.getLogger('viper')
@@ -106,6 +107,11 @@ class Console(object):
     def start(self):
         # log start
         log.info('Starting viper-cli')
+
+        # Initials checks (e.g. for new installation/upgrade of Viper)
+        # make sure PEID info and Yara rules are available in storage path
+        check_and_deploy_peid()
+        check_and_deploy_yara_rules()
 
         # Logo.
         logo()

--- a/viper/modules/pe.py
+++ b/viper/modules/pe.py
@@ -37,6 +37,7 @@ from viper.common.utils import get_type, get_md5
 from viper.core.database import Database
 from viper.core.storage import get_sample_path
 from viper.core.session import __sessions__
+from viper.core.project import __project__
 
 
 class PE(Module):
@@ -305,7 +306,9 @@ class PE(Module):
 
         def get_signatures():
             userdb_path = None
-            for path_attempt in ['/usr/share/viper/peid/UserDB.TXT', os.path.join(VIPER_ROOT, 'data/peid/UserDB.TXT')]:
+            for path_attempt in ['/usr/share/viper/peid/UserDB.TXT',
+                                 os.path.join(__project__.base_path, 'peid/UserDB.TXT'),
+                                 os.path.join(VIPER_ROOT, 'data/peid/UserDB.TXT')]:
                 if os.path.exists(path_attempt):
                     userdb_path = path_attempt
                     break

--- a/viper/modules/pe.py
+++ b/viper/modules/pe.py
@@ -307,8 +307,7 @@ class PE(Module):
         def get_signatures():
             userdb_path = None
             for path_attempt in ['/usr/share/viper/peid/UserDB.TXT',
-                                 os.path.join(__project__.base_path, 'peid/UserDB.TXT'),
-                                 os.path.join(VIPER_ROOT, 'data/peid/UserDB.TXT')]:
+                                 os.path.join(__project__.base_path, 'peid/UserDB.TXT')]:
                 if os.path.exists(path_attempt):
                     userdb_path = path_attempt
                     break

--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -5,7 +5,6 @@
 import os
 import string
 import subprocess
-from os.path import expanduser
 
 try:
     from scandir import walk
@@ -14,9 +13,11 @@ except ImportError:
 
 from viper.common.abstracts import Module
 from viper.core.database import Database
+from viper.core.project import __project__
 from viper.core.session import __sessions__
 from viper.core.storage import get_sample_path
 from viper.core.config import __config__
+from viper.common.constants import VIPER_ROOT
 
 try:
     import yara
@@ -56,10 +57,12 @@ class YaraScan(Module):
         parser_rules.add_argument('-e', '--edit', help='Open an editor to edit the specified rule')
         parser_rules.add_argument('-u', '--update', action='store_true', help='Download latest rules from selected repositories')
 
-        self.local_rules = os.path.join(expanduser('~'), '.viper', 'data', 'yara')
+        self.local_rules = os.path.join(__project__.base_path, 'yara')
+
         self.rules_paths = [
             '/usr/share/viper/yara',
-            self.local_rules
+            self.local_rules,
+            os.path.join(VIPER_ROOT, 'data', 'yara')
         ]
 
     def _get_rules(self):

--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -61,8 +61,7 @@ class YaraScan(Module):
 
         self.rules_paths = [
             '/usr/share/viper/yara',
-            self.local_rules,
-            os.path.join(VIPER_ROOT, 'data', 'yara')
+            self.local_rules
         ]
 
     def _get_rules(self):


### PR DESCRIPTION
In my change request #534 @botherder correctly pointed out that there were some changes to the way yara rule (and peid) files are handled. I have extracted those changes and but them into this new PR.

Before this change the yara rules and the peid file were used either from `/usr/share/viper/peid/UserDB.TXT` or from the git checkout directory. Both directories are potentially changed when updating/removing Viper. 

Therefore this PR adds these two directories: 

* `os.path.join(__project__.base_path, "peid")`
* `os.path.join(__project__.base_path, "yara")`

The `__project__.base_path` usually is `~/.viper/` - the path where the databases and binaries are stored - and which therefore is writable and already contains "user content". In my opinion it also makes sense to have the yara rules (and peid UserDB) there. Especially as users might add their own rules or even modify existing rules.

This PR also ensures on a new install/when it's first run that the directories are initially provisioned with the default files.

I stumbled over this because the web interface has a section that let's user edit the yara rules. If the rules are in a directory that is not writable for the user or which will be overwritten on the next update/git pull this doesn't work/make any sense.