### PR TITLE
Update line 160 for python3 compatability

### DIFF
--- a/data/web/index.tpl
+++ b/data/web/index.tpl
@@ -157,7 +157,7 @@
 
 <%
 # number of pages
-num_pages = count / 25
+num_pages = count // 25
 if num_pages % 25 > 0:
     num_pages += 1
 end


### PR DESCRIPTION
the range() in line 173 only takes integer under python 3.6 "100 / 25" results in 4.0 (float) using "//" fixes this.