### PR TITLE
Forced match variable to bytes-like for Python 3 compatability

### DIFF
--- a/viper/modules/pe.py
+++ b/viper/modules/pe.py
@@ -751,7 +751,7 @@ class PE(Module):
 
         def check_module(iat, match):
             for imp in iat:
-                if imp.find(match) != -1:
+                if bytes(match, 'utf-8') in imp:
                     return True
 
             return False


### PR DESCRIPTION
In "pe language" it was throwing error "TypeError: a bytes-like object is required, not 'str'" in Pyhon 3.6 .
Forced 'match' as a bytes-like. tested this on 3.6 I can't test this on Python 2.7 this needs to be verified.