### PR TITLE
Allow switching projects only on SQLite

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -193,6 +193,8 @@ class Database:
 
     def __init__(self):
 
+        self.supports_projects = False  # currently only sqlite support projects
+
         if cfg.database and cfg.database.connection:
             self._connect_database(cfg.database.connection)
         else:
@@ -218,6 +220,7 @@ class Database:
         elif connection.startswith("postgresql"):
             self.engine = create_engine(connection, connect_args={"sslmode": "disable"})
         else:
+            self.supports_projects = True
             db_path = os.path.join(__project__.get_path(), 'viper.db')
             self.engine = create_engine('sqlite:///{0}'.format(db_path), poolclass=NullPool)
 

--- a/viper/core/ui/cmd/projects.py
+++ b/viper/core/ui/cmd/projects.py
@@ -63,6 +63,7 @@ class Projects(Command):
 
             self.log("table", dict(header=["Project Name", "Creation Time", "Current"], rows=rows))
         elif args.switch:
+            db = Database()
             if not db.supports_projects:
                 self.log('info', "The database type you are using does not support projects")
                 return

--- a/viper/core/ui/cmd/projects.py
+++ b/viper/core/ui/cmd/projects.py
@@ -63,6 +63,10 @@ class Projects(Command):
 
             self.log("table", dict(header=["Project Name", "Creation Time", "Current"], rows=rows))
         elif args.switch:
+            if not db.supports_projects:
+                self.log('info', "The database type you are using does not support projects")
+                return
+
             if __sessions__.is_set():
                 __sessions__.close()
                 self.log("info", "Closed opened session")


### PR DESCRIPTION
In the current situation Viper only handles projects correctly if the database backend is SQLite. When a users switches from the default projects to a new project Viper simply creates a new `viper.db` SQLite database in the project sub-folder. 

With other backends (e.g. PostgreSQL) it is at the moment not possible to create a new, separate database and therefore it should not be possible to use `--switch` on other backends than SQLite.

This relates to #650. 