### PR TITLE
also show default as project initially

### DIFF
--- a/viper/core/ui/console.py
+++ b/viper/core/ui/console.py
@@ -214,9 +214,10 @@ class Console(object):
             # TODO: perhaps this block should be moved into the session so that
             # the generation of the prompt is done only when the session's
             # status changes.
-            prefix = ''
             if __project__.name:
                 prefix = bold(cyan(__project__.name)) + ' '
+            else:
+                prefix = bold(cyan('default')) + ' '
 
             if __sessions__.is_set():
                 stored = ''


### PR DESCRIPTION
Is there a reason why `default` is not included in the prompt when initially starting Viper?

As soon as I switch to a project and then back to `default` it will be included....

Before
![before](https://user-images.githubusercontent.com/6499251/36501046-5508ec6e-1746-11e8-8e80-64f8ba2a83ec.png)

After
![after](https://user-images.githubusercontent.com/6499251/36501045-53f8635e-1746-11e8-8769-1509bc6af992.png)


