### PR TITLE
This allows yara make usage of rules created through web

### DIFF
--- a/viper/modules/yarascan.py
+++ b/viper/modules/yarascan.py
@@ -57,9 +57,11 @@ class YaraScan(Module):
         parser_rules.add_argument('-u', '--update', action='store_true', help='Download latest rules from selected repositories')
 
         self.local_rules = os.path.join(expanduser('~'), '.viper', 'data', 'yara')
+        local_user_rules = os.path.join(expanduser('~'), '.viper', 'yara')
         self.rules_paths = [
             '/usr/share/viper/yara',
-            self.local_rules
+            self.local_rules,
+            local_user_rules
         ]
 
     def _get_rules(self):


### PR DESCRIPTION
When a new rule are created through the web interface, the file is saved in **~/.viper/yara**, and this path are not used while scan.