### PR TITLE
chg: [fix] viper-web is broken with Django 2.1

### DIFF
--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -1,4 +1,4 @@
-Django
+Django==2.0.8
 django-bootstrap-form
 django-crispy-forms
 django-extensions


### PR DESCRIPTION
This will install Django 2.0.8 until updated to Django 2.1