### PR TITLE
fix Travis tests

### DIFF
--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -4,10 +4,10 @@ django-crispy-forms
 django-extensions
 django-favicon
 django-filter
-django-rest-swagger
+django-rest-swagger==2.1.2
 django-sslserver
 django-url-filter
 djangorestframework
 djangorestframework-queryfields
 drf-nested-routers
-whitenoise==4.0b4
+whitenoise

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,13 @@ whitelist_externals =
     git
     bash
     rm
+    python
 commands =
     git submodule sync -q
     git submodule update --init
     rm -rf {toxworkdir}/.viper
     bash -c 'echo "exit" | python viper-cli'
+    python manage.py collectstatic
     pytest {posargs}
     codecov
     rm -rf {toxworkdir}/.viper

--- a/viper/web/settings.py
+++ b/viper/web/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'django_extensions',
     'favicon',
@@ -60,8 +61,8 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = [
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/viper/web/wsgi.py
+++ b/viper/web/wsgi.py
@@ -6,9 +6,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from whitenoise import WhiteNoise
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "web.settings")
 
 application = get_wsgi_application()
-application = WhiteNoise(application)


### PR DESCRIPTION
There currently seem to be two issue with the travis tests.
1) Whitenoise has changed the handling of the files so that it could not serve the static files. Running manage.py collectstatic within Travis will collect the files and store them in the correct location.
2) The API documentation application (Django Rest Swagger) changed the way to customize the interface. For now I'm pinning this to the last working version.

Tests **should** now be green.. let's see.. :-D