### PR TITLE
Make result from 'file' command a string

### DIFF
--- a/viper/common/objects.py
+++ b/viper/common/objects.py
@@ -194,7 +194,7 @@ class File(object):
                 try:
                     import subprocess
                     file_process = subprocess.Popen(['file', '-b', self.path], stdout=subprocess.PIPE)
-                    file_type = file_process.stdout.read().strip()
+                    file_type = file_process.stdout.read().strip().decode("utf-8")
                 except Exception:
                     return ''
         finally:


### PR DESCRIPTION
If `import magic` fails, viper will use the output of the `file` command to determine the filetype. However, the returned value is a byte string instead of a string, which breaks some functionality (including yara scanning). This PR fixes that.