### PR TITLE
Use xxd instead of hd on Macs when getting the hex view in viperweb

### DIFF
--- a/viper/web/viperweb/views.py
+++ b/viper/web/viperweb/views.py
@@ -10,6 +10,7 @@ import tempfile
 import contextlib
 import shutil
 import requests
+import platform
 from operator import itemgetter
 
 # Logging
@@ -490,6 +491,8 @@ class HexView(LoginRequiredMixin, TemplateView):
 
         # create the command string
         hex_cmd = 'hd -s {0} -n {1} {2}'.format(hex_offset, hex_length, hex_path)
+        if platform.system() == 'Darwin':
+            hex_cmd = 'xxd -s {0} -l {1} {2}'.format(hex_offset, hex_length, hex_path)
 
         # get the output
         hex_string = getoutput(hex_cmd)


### PR DESCRIPTION
Macs don't ship the hd utility by default, so using the hex view functionality in the web UI doesn't work. This PR adds an OS check and uses xxd instead when macOS is detected.

The color formatting is a little screwed up since xxd and hd have slightly different output, but it's better than nothing.