### PR TITLE
Replaced dependency for PyExifTool

### DIFF
--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -92,4 +92,4 @@ git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
 git+https://github.com/MISP/PyMISPGalaxies.git#egg=PyMISPGalaxies
 
 # EXIF Module
-git+https://github.com/smarnach/pyexiftool.git#egg=PyExifTool
+ocrd-pyexiftool==0.2.0


### PR DESCRIPTION
Replaced dependency for PyExifTool in order to use a wheel on pypi (https://pypi.org/project/ocrd-pyexiftool/) that is a fork of that repository (https://github.com/OCR-D/pyexiftool)