### PR TITLE
Fix: #675

### DIFF
--- a/viper/modules/virustotal.py
+++ b/viper/modules/virustotal.py
@@ -247,7 +247,7 @@ class VirusTotal(Module):
         if cfg.virustotal.virustotal_has_private_key:
             response = self.vt.get_file(filehash)
             if not self._has_fail(response):
-                with open(filename, 'w') as f:
+                with open(filename, 'wb') as f:
                     f.write(response)
             else:
                 return
@@ -422,7 +422,7 @@ class VirusTotal(Module):
         if to_search:
             self.scan(to_search, self.args.verbose, self.args.submit, path_to_submit)
             if self.args.download:
-                self.download(to_search, self.args.verbose)
+                self.download(to_search, verbose=self.args.verbose)
 
             if self.args.comment:
                 response = self.vt.put_comments(to_search, ' '.join(self.args.comment))

--- a/viper/web/viperweb/templates/viperweb/index.html
+++ b/viper/web/viperweb/templates/viperweb/index.html
@@ -34,8 +34,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link disabled" id="nav-download-vt-tab" data-toggle="tab" href="#nav-download-vt" role="tab" aria-controls="nav-download-vt" aria-selected="false">
-                            Download Sample from Virustotal (disabled)
+                        <a class="nav-link" id="nav-download-vt-tab" data-toggle="tab" href="#nav-download-vt" role="tab" aria-controls="nav-download-vt" aria-selected="false">
+                            Download Sample from Virustotal
                         </a>
                     </li>
                 </ul>

--- a/viper/web/viperweb/views.py
+++ b/viper/web/viperweb/views.py
@@ -366,7 +366,9 @@ class VtDownloadView(LoginRequiredMixin, TemplateView):
 
         vt_hash = request.POST.get('vt_hash')
         tags = request.POST.get('tag_list')
-        cmd_line = 'virustotal -d {0}; store; tags -a {1}'.format(vt_hash, tags)
+        cmd_line = 'virustotal -search {0} -d; store'.format(vt_hash)
+        if len(tags) > 0:
+          cmd_line += '; tags -a {0}'.format(tags)
 
         module_results = module_cmdline(project=project, file_hash=False, cmd_line=cmd_line)
 

--- a/viper/web/viperweb/views.py
+++ b/viper/web/viperweb/views.py
@@ -366,7 +366,7 @@ class VtDownloadView(LoginRequiredMixin, TemplateView):
 
         vt_hash = request.POST.get('vt_hash')
         tags = request.POST.get('tag_list')
-        cmd_line = 'virustotal -search {0} -d; store'.format(vt_hash)
+        cmd_line = 'virustotal --search {0} -d; store'.format(vt_hash)
         if len(tags) > 0:
           cmd_line += '; tags -a {0}'.format(tags)
 

--- a/viper/web/viperweb/views.py
+++ b/viper/web/viperweb/views.py
@@ -234,9 +234,11 @@ def module_cmdline(project=None, cmd_line=None, file_hash=None):
         root, args = parse(split_command)
         try:
             if root in cmd.commands:
-                cmd.commands[root]['obj'](*args)
-                html += print_output(cmd.output)
-                del (cmd.output[:])
+                cmd_to_run = cmd.commands[root]['obj']
+                cmd_to_run(*args)
+                cmd_instance = cmd_to_run.__self__
+                html += print_output(cmd_instance.output)
+                del (cmd_instance.output[:])
             elif root in __modules__:
                 # if prev commands did not open a session open one on the current file
                 if file_hash:


### PR DESCRIPTION
'Download Sample from VirusTotal' was broken;
(1) The command VtDownloadView runs was wrong.
`virustotal -d {hash}` doesn't work. `virustotal --search {hash} -d` does work.
And also I modified VtDownloadView to allow user to omit tags.

(2) The way VirusTotal module treats --verbose  option was not correct in our case.
When we use the module to download a file by using -d option, args.verbose is passed as `open_session` arg of the `download` method.

(3) The VirusTotal module tries to write malware binary as `text file` (open(filename, 'w'))
In most cases malware binary cannot be treated as a text file, so the code shown below throws a runtime error in most cases.
```
with open(filename, 'w') as f:
  f.write(response)
```

This case, mode should be 'wb'

(4) module_cmdline (defined in views.py) cannot capture cmd.output
.output is not defined in Commands, so it always returns None, and so VtDownloadView.post always fails.

This PR fixes these bugs.