### PR TITLE
Add support for project notes

### DIFF
--- a/docs/source/usage/commands.rst
+++ b/docs/source/usage/commands.rst
@@ -292,15 +292,16 @@ notes
 During an analysis you might want to keep track of your discoveries and results. Instead of having unorganized text files lying around, Viper allows you to create notes directly linked to the relevant files and even search across them.
 When you have a file opened, you can add any number of text notes associated to it through the ``notes`` command. This is the help message::
 
-    usage: notes [-h] [-l] [-a] [-e <note id>] [-d <note id>]
+    usage: notes [-h] [-l] [-a] [-e <note id>] [-d <note id>] [-p]
 
     Options:
-        --help (-h) Show this help message
-        --list (-h) List all notes available for the current file
-        --add (-a)  Add a new note to the current file
-        --view (-v) View the specified note
-        --edit (-e) Edit an existing note
-        --delete (-d)   Delete an existing note
+        --help (-h)    Show this help message
+        --list (-h)    List all notes available for the current file
+        --add (-a)     Add a new note to the current file
+        --view (-v)    View the specified note
+        --edit (-e)    Edit an existing note
+        --delete (-d)  Delete an existing note
+        --project (-p) Use project notes instead of notes being tied to a file
 
 As shown in the help message, you can list add a note::
 
@@ -325,6 +326,20 @@ Now you can see the new note in the list and view its content::
     - poisonivy.malicious.tld
     - poisonivy2.malicious.tld
 
+It is also possible to add notes directly to the project without associating it to a file.
+With no file open, notes created will only be added to the project. If a file is open, a project note can be added by using the ``--project`` flag::
+
+    shell poisonivy.exe > notes --add --project
+    Enter a title for the new note:
+
+You can list the project notes when a file is open with the command shown below::
+
+    shell poisonivy.exe > notes --list --project
+    +----+---------+
+    | ID | Title   |
+    +----+---------+
+    | 1  | Domains |
+    +----+---------+
 
 open
 ====

--- a/tests/core/ui/test_commands.py
+++ b/tests/core/ui/test_commands.py
@@ -44,7 +44,7 @@ class TestCommands:
 
         self.cmd['notes']['obj']('-l')
         out, err = capsys.readouterr()
-        assert re.search(".*No open session.*", out)
+        assert re.search(".*No notes available for this file or.*", out)
 
     def test_open(self, capsys):
         self.cmd['open']['obj']('-h')

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -308,13 +308,18 @@ class Database:
                 raise Python2UnsupportedUnicode("Non ASCII character(s) in Notes not supported on Python2.\n"
                                                 "Please use Python >= 3.4".format(err), "error")
 
-        malware_entry = session.query(Malware).filter(Malware.sha256 == sha256).first()
-        if not malware_entry:
-            return
+        if sha256 is not None:
+            malware_entry = session.query(Malware).filter(Malware.sha256 == sha256).first()
+            if not malware_entry:
+                return
 
         try:
             new_note = Note(title, body)
-            malware_entry.note.append(new_note)
+            if sha256 is not None:
+                malware_entry.note.append(new_note)
+            else:
+                session.add(new_note)
+
             session.commit()
             self.added_ids.setdefault("note", []).append(new_note.id)
         except SQLAlchemyError as e:


### PR DESCRIPTION
Support for notes that are not associated with a file. A user can create
a new project note by calling the notes command with the flag --add when
no file is open. To create a project file when a file is open, include
the --project flag. It is also possible to list all notes in the
project using the --list flag when no file is open or including the
--project flag when a file is open.

# Example
```
demo viper > notes --list
[*] No notes available for this file or project yet
demo viper > notes --add
Enter a title for the new note: No session project note
[*] New note with title "No session project note" added to the current project
...
demo viper demo file > notes --add --project
Enter a title for the new note: Project note from session
[*] New note with title "Project note from session" added to the current project
demo viper demo file > notes --add
Enter a title for the new note: Session note
[*] New note with title "Session note" added to the current file
demo viper demo file > notes --list
+----+--------------+
| ID | Title        |
+----+--------------+
| 3  | Session note |
+----+--------------+
demo viper demo file > notes --list --project
+----+--------------------------+
| ID | Title                    |
+----+--------------------------+
| 1  | No session project note  |
| 2  | Project note from session |
| 3  | Session note             |
+----+--------------------------+

```