### PR TITLE
More strings module flags: r2 and xor

### DIFF
--- a/viper/common/objects.py
+++ b/viper/common/objects.py
@@ -88,6 +88,22 @@ class MispEvent(object):
         return event_hashes, sample_hashes
 
 
+class IOBytes(object):
+    def __init__(self, byte_array):
+        """
+        Use to emulate some of the File object features so that a
+        io.ByteIO instance can be treated like a file when it comes
+        to calling the data property.
+
+        @byte_array: a io.BytesIO instance
+        """
+        self._data = byte_array
+
+    @property
+    def data(self):
+        return self._data
+
+
 class File(object):
     def __init__(self, path):
         self.id = None

--- a/viper/modules/strings.py
+++ b/viper/modules/strings.py
@@ -181,7 +181,7 @@ class Strings(Module):
         '''
             Uses r2 izzj to pull strings from the binary
 
-            returns a dict: offset, value 
+            returns a dict: offset, value
         '''
         results = []
 


### PR DESCRIPTION
These are two commands I've been using for awhile in my local viper instance and wanted to share.

Added two features to the strings module.  

1. `-x` which accepts a single byte xor key that the data is xor'ed with before any filters are applied (`-H`, `-N`, etc.).  The idea here is to take the key found from the `xor` command and apply it to strings.

1. `-r` added as a second string extraction method using r2.  Sometimes r2 finds strings not found by the default string extraction method and sometimes the default finds strings r2 does not find.  The `-x` flag does not work with the `-r` flag.

The modification to objects.py is to support xor operation in strings.  Let me know if I should do this differently. 