### PR TITLE
Improve update-modules command

### DIFF
--- a/viper/core/ui/cmd/update-modules.py
+++ b/viper/core/ui/cmd/update-modules.py
@@ -28,7 +28,7 @@ class UpdateModules(Command):
             p.wait()
         else:
             # Clone the repository.
-            p = subprocess.Popen(["git", "clone", "git@github.com:viper-framework/viper-modules.git",
+            p = subprocess.Popen(["git", "clone", "https://github.com/viper-framework/viper-modules.git",
                 "modules"], cwd=dot_viper)
             p.wait()
 

--- a/viper/core/ui/cmd/update-modules.py
+++ b/viper/core/ui/cmd/update-modules.py
@@ -32,6 +32,11 @@ class UpdateModules(Command):
                 "modules"], cwd=dot_viper)
             p.wait()
 
+            # Check whether previous command executed successfully
+            if p.returncode != 0:
+                self.log("error", "Module download failed. Returncode of `git clone ...`: " + str(p.returncode))
+                return
+
         # Initialize submodules.
         p = subprocess.Popen(["git", "submodule", "init"], cwd=dot_viper_modules)
         p.wait()


### PR DESCRIPTION
Fixes #770 

- Switch to https for initially downloading modules (which works also behind a normal http(s) proxy)
- Check whether the command has been executed successfully (not doing so can lead to misleading error messages)