### PR TITLE
unrar is not available by default, but unrar-free is

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -51,7 +51,7 @@ On the first launch you will notice that Viper warns you that you do not have an
 
 In order to have support for the most basic modules, you will need to install the following dependencies too before proceeding::
 
-    $ sudo apt-get install libssl-dev swig libffi-dev ssdeep libfuzzy-dev unrar p7zip-full
+    $ sudo apt-get install libssl-dev swig libffi-dev ssdeep libfuzzy-dev unrar-free p7zip-full
 
 You can now download the modules directly from our community GitHub repository using::
 


### PR DESCRIPTION
unrar-free also successfully installs with community modules

```
[*] Updating modules...
[*] Modules updated, please relaunch `viper`.
Removing intermediate container 7a6b455cc274
 ---> 6039f5e1e7de
Successfully built 6039f5e1e7de
Successfully tagged viper-base-community:latest
```