### PR TITLE
Update database.py - fix default created time

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -54,7 +54,7 @@ class Malware(Base):
     sha256 = Column(String(64), nullable=False, index=True)
     sha512 = Column(String(128), nullable=False)
     ssdeep = Column(String(255), nullable=True)
-    created_at = Column(DateTime(timezone=False), default=datetime.now(), nullable=False)
+    created_at = Column(DateTime(timezone=False), default=datetime.now, nullable=False)
     parent_id = Column(Integer(), ForeignKey('malware.id'))
     parent = relationship('Malware', lazy='subquery', remote_side=[id])
     tag = relationship(


### PR DESCRIPTION
Default created time should be now and not now().
datetime.now() will set default created time to the time of the viper instance restart. 
datetime.now will use the date at the time of the row creation, as intended